### PR TITLE
remove last argument from Bool get

### DIFF
--- a/src/ColorSchemes.jl
+++ b/src/ColorSchemes.jl
@@ -214,8 +214,7 @@ function get(cscheme::ColorScheme, x::AllowedInput, rangescale::NTuple{2,<:Real}
     return weighted_color_mean.(1 .- cpt, cscheme.colors[before], cscheme.colors[after])
 end
 # Boolean just takes the start and end values of the scheme. Also avoid using a branch.
-function get(cscheme::ColorScheme, x::Union{Bool,AbstractArray{Bool}},
-             rangescale::NTuple{2,<:Real}=defaultrange(x))
+function get(cscheme::ColorScheme, x::Union{Bool,AbstractArray{Bool}})
     i = x .* (length(cscheme) .- 1) .+ 1
     return getindex.(Ref(cscheme.colors), i)
 end


### PR DESCRIPTION
This was a very small bug that I introduced in `get` for `Bool` - it cant have a rangescale argument. If it does it needs to be treated like any other `Real`. The idea was only to make it fast for `Bool` with no rangescale argument as we know from the type that it is between 0 and 1 and it needs no processing.