### PR TITLE
Fix type stability of get

### DIFF
--- a/src/ColorSchemes.jl
+++ b/src/ColorSchemes.jl
@@ -204,8 +204,10 @@ function get(cscheme::ColorScheme, x::AllowedInput, rangemode::Symbol)
 end
 function get(cscheme::ColorScheme, x::AllowedInput, rangescale::NTuple{2,<:Real}=defaultrange(x))
     x isa AbstractRange && (x = collect(x))
-    # check for empty range (#43)
-    iszero(first(rangescale) - last(rangescale)) && (rangescale=(0.0, 1.0))
+    # check for empty range
+    if iszero(first(rangescale) - last(rangescale)) 
+        rangescale = zero(first(rangescale)), oneunit(last(rangescale))
+    end
     x = clamp.(x, rangescale...)
     before_fp = remap(x, rangescale..., 1, length(cscheme))
     before = round.(Int, before_fp, RoundDown)


### PR DESCRIPTION
A recent PR used Float64 values instead of `zero` etc here: https://github.com/JuliaGraphics/ColorSchemes.jl/blob/master/src/ColorSchemes.jl#L208

Would it be ok to add some `@inferred` tests to keep this type stable?

I tried to add those to this PR but unfortunately `weighted_color_mean` in Colors.jl isn't type-stable either! Although it has much less of a performance cost than type instability in rangescale (which makes DynamicGrids.jl visualizations an order of magnitude slower). 

I'll try to fix the type-stability in Colors.jl and make another PR with type-stability tests here.