### PR TITLE
Throw ArgumentError instead of Error for unsupported rangescale

### DIFF
--- a/src/ColorSchemes.jl
+++ b/src/ColorSchemes.jl
@@ -278,7 +278,7 @@ function get(cscheme::ColorScheme, x::AllowedInput, rangemode::Symbol)
     elseif rangemode == :centered
         (-1, 1) .* maximum(abs, x)
     else
-        error("rangescale ($rangemode) not supported, should be :clamp, :extrema, :centered or tuple (minVal, maxVal)")
+        throw(ArgumentError("rangescale :$rangemode not supported, should be :clamp, :extrema, :centered or tuple (minVal, maxVal)"))
     end
     get(cscheme, x, rangescale)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,6 +184,9 @@ end
     @test isapprox(y3[2], y2[2])
     @test isapprox(y3[end], y2[end])
 
+    # test error on unknown rangescale
+    @test_throws ArgumentError get(monalisa1, x, :foo)
+
     # tests concatenation
     l1 = length(monalisa)
     l2 = length(monalisa * monalisa)


### PR DESCRIPTION
Not strictly necessary, but this makes the error more specific and testable, increasing code coverage.