### PR TITLE
jcolors.jl: remove LICENSE notice (close #146)

### DIFF
--- a/data/jcolors.jl
+++ b/data/jcolors.jl
@@ -1,5 +1,3 @@
-# see license information at https://github.com/JuliaLang/julia-logo-graphics/LICENSE.md
-
 loadcolorscheme(:julia, [
     colorant"#1f83ff", # blue
     colorant"#CA3C32", # red


### PR DESCRIPTION
Color schemes are not eligible for copyright protection, so the Julia logo license does not apply here. If there's any concern, I am also the copyright owner for the Julia logo.