### PR TITLE
Add color combinations from "A dictionary of color combinations" by Sanzo Wada

### DIFF
--- a/data/sanzo.jl
+++ b/data/sanzo.jl
@@ -1,1703 +1,1701 @@
-# Color combinations from Sanzo Wada's "A Dictionary of Color Combinations"
-
 loadcolorscheme(:sanzo_1, [
-        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzo", "Color combination 1 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
+], "sanzo", "Sanzo Wada, Combination 1")
 loadcolorscheme(:sanzo_2, [
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzo", "Color combination 2 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
+], "sanzo", "Sanzo Wada, Combination 2")
 loadcolorscheme(:sanzo_3, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-    ], "sanzo", "Color combination 3 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 3")
 loadcolorscheme(:sanzo_4, [
-        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 4 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 4")
 loadcolorscheme(:sanzo_5, [
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzo", "Color combination 5 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 5")
 loadcolorscheme(:sanzo_6, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzo", "Color combination 6 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
+], "sanzo", "Sanzo Wada, Combination 6")
 loadcolorscheme(:sanzo_7, [
-        RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzo", "Color combination 7 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 7")
 loadcolorscheme(:sanzo_8, [
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzo", "Color combination 8 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
+], "sanzo", "Sanzo Wada, Combination 8")
 loadcolorscheme(:sanzo_9, [
-        RGB(0.23921568627450981, 0.0, 0.4745098039215686),
-        RGB(0.43137254901960786, 0.4, 0.8313725490196079),
-    ], "sanzo", "Color combination 9 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.23921568627450981, 0.0, 0.4745098039215686),
+        RGB(0.43137254901960786, 0.4, 0.8313725490196079)
+], "sanzo", "Sanzo Wada, Combination 9")
 loadcolorscheme(:sanzo_10, [
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
-    ], "sanzo", "Color combination 10 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157)
+], "sanzo", "Sanzo Wada, Combination 10")
 loadcolorscheme(:sanzo_11, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
-    ], "sanzo", "Color combination 11 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745)
+], "sanzo", "Sanzo Wada, Combination 11")
 loadcolorscheme(:sanzo_12, [
-        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzo", "Color combination 12 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 12")
 loadcolorscheme(:sanzo_13, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-    ], "sanzo", "Color combination 13 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647)
+], "sanzo", "Sanzo Wada, Combination 13")
 loadcolorscheme(:sanzo_14, [
-        RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-    ], "sanzo", "Color combination 14 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902)
+], "sanzo", "Sanzo Wada, Combination 14")
 loadcolorscheme(:sanzo_15, [
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzo", "Color combination 15 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
+], "sanzo", "Sanzo Wada, Combination 15")
 loadcolorscheme(:sanzo_16, [
-        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzo", "Color combination 16 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
+], "sanzo", "Sanzo Wada, Combination 16")
 loadcolorscheme(:sanzo_17, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
-        RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzo", "Color combination 17 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.2, 1.0, 0.49019607843137253)
+], "sanzo", "Sanzo Wada, Combination 17")
 loadcolorscheme(:sanzo_18, [
-        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+    RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzo", "Color combination 18 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
+], "sanzo", "Sanzo Wada, Combination 18")
 loadcolorscheme(:sanzo_19, [
-        RGB(0.3215686274509804, 0.12549019607843137, 0.0),
-        RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzo", "Color combination 19 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.3215686274509804, 0.12549019607843137, 0.0),
+        RGB(0.47843137254901963, 1.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 19")
 loadcolorscheme(:sanzo_20, [
-        RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
-    ], "sanzo", "Color combination 20 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.5019607843137255, 1.0, 0.8),
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 20")
 loadcolorscheme(:sanzo_21, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzo", "Color combination 21 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.2, 1.0, 0.49019607843137253)
+], "sanzo", "Sanzo Wada, Combination 21")
 loadcolorscheme(:sanzo_22, [
-        RGB(1.0, 1.0, 0.0),
+    RGB(1.0, 1.0, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzo", "Color combination 22 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.1411764705882353, 0.8)
+], "sanzo", "Sanzo Wada, Combination 22")
 loadcolorscheme(:sanzo_23, [
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzo", "Color combination 23 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 23")
 loadcolorscheme(:sanzo_24, [
-        RGB(0.3137254901960784, 0.23921568627450981, 0.0),
-        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-    ], "sanzo", "Color combination 24 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.3137254901960784, 0.23921568627450981, 0.0),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647)
+], "sanzo", "Sanzo Wada, Combination 24")
 loadcolorscheme(:sanzo_25, [
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzo", "Color combination 25 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 25")
 loadcolorscheme(:sanzo_26, [
-        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-    ], "sanzo", "Color combination 26 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255)
+], "sanzo", "Sanzo Wada, Combination 26")
 loadcolorscheme(:sanzo_27, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 27 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 27")
 loadcolorscheme(:sanzo_28, [
-        RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzo", "Color combination 28 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
+], "sanzo", "Sanzo Wada, Combination 28")
 loadcolorscheme(:sanzo_29, [
-        RGB(0.4588235294117647, 0.5725490196078431, 0.2627450980392157),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 29 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.4588235294117647, 0.5725490196078431, 0.2627450980392157),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 29")
 loadcolorscheme(:sanzo_30, [
-        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
-        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
-    ], "sanzo", "Color combination 30 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745)
+], "sanzo", "Sanzo Wada, Combination 30")
 loadcolorscheme(:sanzo_31, [
-        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-    ], "sanzo", "Color combination 31 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 31")
 loadcolorscheme(:sanzo_32, [
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzo", "Color combination 32 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.47843137254901963, 1.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 32")
 loadcolorscheme(:sanzo_33, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 33 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 33")
 loadcolorscheme(:sanzo_34, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 34 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 34")
 loadcolorscheme(:sanzo_35, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-    ], "sanzo", "Color combination 35 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217)
+], "sanzo", "Sanzo Wada, Combination 35")
 loadcolorscheme(:sanzo_36, [
-        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzo", "Color combination 36 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 36")
 loadcolorscheme(:sanzo_37, [
-        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 37 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 37")
 loadcolorscheme(:sanzo_38, [
-        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzo", "Color combination 38 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.0, 0.1411764705882353, 0.8)
+], "sanzo", "Sanzo Wada, Combination 38")
 loadcolorscheme(:sanzo_39, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzo", "Color combination 39 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
+], "sanzo", "Sanzo Wada, Combination 39")
 loadcolorscheme(:sanzo_40, [
-        RGB(0.7803921568627451, 0.2627450980392157, 0.0),
-    ], "sanzo", "Color combination 40 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7803921568627451, 0.2627450980392157, 0.0)
+], "sanzo", "Sanzo Wada, Combination 40")
 loadcolorscheme(:sanzo_41, [
-        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
-        RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzo", "Color combination 41 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
+        RGB(0.5019607843137255, 1.0, 0.8)
+], "sanzo", "Sanzo Wada, Combination 41")
 loadcolorscheme(:sanzo_42, [
-        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 42 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 42")
 loadcolorscheme(:sanzo_43, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzo", "Color combination 43 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 43")
 loadcolorscheme(:sanzo_44, [
-        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzo", "Color combination 44 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 44")
 loadcolorscheme(:sanzo_45, [
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-    ], "sanzo", "Color combination 45 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725)
+], "sanzo", "Sanzo Wada, Combination 45")
 loadcolorscheme(:sanzo_46, [
-        RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 46 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 46")
 loadcolorscheme(:sanzo_47, [
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzo", "Color combination 47 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
+], "sanzo", "Sanzo Wada, Combination 47")
 loadcolorscheme(:sanzo_48, [
-        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzo", "Color combination 48 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
+], "sanzo", "Sanzo Wada, Combination 48")
 loadcolorscheme(:sanzo_49, [
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 49 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 49")
 loadcolorscheme(:sanzo_50, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzo", "Color combination 50 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
+], "sanzo", "Sanzo Wada, Combination 50")
 loadcolorscheme(:sanzo_51, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 51 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 51")
 loadcolorscheme(:sanzo_52, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 52 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 52")
 loadcolorscheme(:sanzo_53, [
-        RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzo", "Color combination 53 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
+], "sanzo", "Sanzo Wada, Combination 53")
 loadcolorscheme(:sanzo_54, [
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzo", "Color combination 54 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
+], "sanzo", "Sanzo Wada, Combination 54")
 loadcolorscheme(:sanzo_55, [
-        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
-        RGB(1.0, 1.0, 1.0),
-    ], "sanzo", "Color combination 55 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(1.0, 1.0, 1.0)
+], "sanzo", "Sanzo Wada, Combination 55")
 loadcolorscheme(:sanzo_56, [
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 56 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 56")
 loadcolorscheme(:sanzo_57, [
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 57 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 57")
 loadcolorscheme(:sanzo_58, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzo", "Color combination 58 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.2, 1.0, 0.49019607843137253)
+], "sanzo", "Sanzo Wada, Combination 58")
 loadcolorscheme(:sanzo_59, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-    ], "sanzo", "Color combination 59 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744)
+], "sanzo", "Sanzo Wada, Combination 59")
 loadcolorscheme(:sanzo_60, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzo", "Color combination 60 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
+], "sanzo", "Sanzo Wada, Combination 60")
 loadcolorscheme(:sanzo_61, [
-        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzo", "Color combination 61 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
+], "sanzo", "Sanzo Wada, Combination 61")
 loadcolorscheme(:sanzo_62, [
-        RGB(1.0, 1.0, 0.0),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 62 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 1.0, 0.0),
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 62")
 loadcolorscheme(:sanzo_63, [
-        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzo", "Color combination 63 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
+], "sanzo", "Sanzo Wada, Combination 63")
 loadcolorscheme(:sanzo_64, [
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
-    ], "sanzo", "Color combination 64 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177)
+], "sanzo", "Sanzo Wada, Combination 64")
 loadcolorscheme(:sanzo_65, [
-        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzo", "Color combination 65 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.5019607843137255, 1.0, 0.8)
+], "sanzo", "Sanzo Wada, Combination 65")
 loadcolorscheme(:sanzo_66, [
-        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-    ], "sanzo", "Color combination 66 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941)
+], "sanzo", "Sanzo Wada, Combination 66")
 loadcolorscheme(:sanzo_67, [
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzo", "Color combination 67 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
+], "sanzo", "Sanzo Wada, Combination 67")
 loadcolorscheme(:sanzo_68, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
-        RGB(1.0, 1.0, 0.0),
-    ], "sanzo", "Color combination 68 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(1.0, 1.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 68")
 loadcolorscheme(:sanzo_69, [
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 69 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 69")
 loadcolorscheme(:sanzo_70, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzo", "Color combination 70 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
+], "sanzo", "Sanzo Wada, Combination 70")
 loadcolorscheme(:sanzo_71, [
-        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-    ], "sanzo", "Color combination 71 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275)
+], "sanzo", "Sanzo Wada, Combination 71")
 loadcolorscheme(:sanzo_72, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzo", "Color combination 72 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
+], "sanzo", "Sanzo Wada, Combination 72")
 loadcolorscheme(:sanzo_73, [
-        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-    ], "sanzo", "Color combination 73 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255)
+], "sanzo", "Sanzo Wada, Combination 73")
 loadcolorscheme(:sanzo_74, [
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzo", "Color combination 74 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 74")
 loadcolorscheme(:sanzo_75, [
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 75 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 75")
 loadcolorscheme(:sanzo_76, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzo", "Color combination 76 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 76")
 loadcolorscheme(:sanzo_77, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
-    ], "sanzo", "Color combination 77 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275)
+], "sanzo", "Sanzo Wada, Combination 77")
 loadcolorscheme(:sanzo_78, [
-        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzo", "Color combination 78 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
+], "sanzo", "Sanzo Wada, Combination 78")
 loadcolorscheme(:sanzo_79, [
-        RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzo", "Color combination 79 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 79")
 loadcolorscheme(:sanzo_80, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzo", "Color combination 80 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 80")
 loadcolorscheme(:sanzo_81, [
-        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzo", "Color combination 81 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 81")
 loadcolorscheme(:sanzo_82, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzo", "Color combination 82 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
+], "sanzo", "Sanzo Wada, Combination 82")
 loadcolorscheme(:sanzo_83, [
-        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 83 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 83")
 loadcolorscheme(:sanzo_84, [
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzo", "Color combination 84 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
+], "sanzo", "Sanzo Wada, Combination 84")
 loadcolorscheme(:sanzo_85, [
-        RGB(0.7803921568627451, 0.2627450980392157, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 85 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7803921568627451, 0.2627450980392157, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 85")
 loadcolorscheme(:sanzo_86, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzo", "Color combination 86 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.2, 1.0, 0.49019607843137253)
+], "sanzo", "Sanzo Wada, Combination 86")
 loadcolorscheme(:sanzo_87, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-    ], "sanzo", "Color combination 87 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627)
+], "sanzo", "Sanzo Wada, Combination 87")
 loadcolorscheme(:sanzo_88, [
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 88 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 88")
 loadcolorscheme(:sanzo_89, [
-        RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 89 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 89")
 loadcolorscheme(:sanzo_90, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzo", "Color combination 90 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 90")
 loadcolorscheme(:sanzo_91, [
-        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
-        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
-    ], "sanzo", "Color combination 91 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0)
+], "sanzo", "Sanzo Wada, Combination 91")
 loadcolorscheme(:sanzo_92, [
-        RGB(1.0, 0.45098039215686275, 0.6),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzo", "Color combination 92 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
+], "sanzo", "Sanzo Wada, Combination 92")
 loadcolorscheme(:sanzo_93, [
-        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzo", "Color combination 93 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
+], "sanzo", "Sanzo Wada, Combination 93")
 loadcolorscheme(:sanzo_94, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzo", "Color combination 94 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
+], "sanzo", "Sanzo Wada, Combination 94")
 loadcolorscheme(:sanzo_95, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzo", "Color combination 95 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
+], "sanzo", "Sanzo Wada, Combination 95")
 loadcolorscheme(:sanzo_96, [
-        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-    ], "sanzo", "Color combination 96 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0)
+], "sanzo", "Sanzo Wada, Combination 96")
 loadcolorscheme(:sanzo_97, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-    ], "sanzo", "Color combination 97 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078)
+], "sanzo", "Sanzo Wada, Combination 97")
 loadcolorscheme(:sanzo_98, [
-        RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 98 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 98")
 loadcolorscheme(:sanzo_99, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzo", "Color combination 99 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
+], "sanzo", "Sanzo Wada, Combination 99")
 loadcolorscheme(:sanzo_100, [
-        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
-        RGB(0.43137254901960786, 0.4, 0.8313725490196079),
-    ], "sanzo", "Color combination 100 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
+        RGB(0.43137254901960786, 0.4, 0.8313725490196079)
+], "sanzo", "Sanzo Wada, Combination 100")
 loadcolorscheme(:sanzo_101, [
-        RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzo", "Color combination 101 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.0, 0.1411764705882353, 0.8)
+], "sanzo", "Sanzo Wada, Combination 101")
 loadcolorscheme(:sanzo_102, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
-    ], "sanzo", "Color combination 102 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0)
+], "sanzo", "Sanzo Wada, Combination 102")
 loadcolorscheme(:sanzo_103, [
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzo", "Color combination 103 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
+], "sanzo", "Sanzo Wada, Combination 103")
 loadcolorscheme(:sanzo_104, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-    ], "sanzo", "Color combination 104 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804)
+], "sanzo", "Sanzo Wada, Combination 104")
 loadcolorscheme(:sanzo_105, [
-        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-    ], "sanzo", "Color combination 105 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353)
+], "sanzo", "Sanzo Wada, Combination 105")
 loadcolorscheme(:sanzo_106, [
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzo", "Color combination 106 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
+], "sanzo", "Sanzo Wada, Combination 106")
 loadcolorscheme(:sanzo_107, [
-        RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
-    ], "sanzo", "Color combination 107 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765)
+], "sanzo", "Sanzo Wada, Combination 107")
 loadcolorscheme(:sanzo_108, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
-    ], "sanzo", "Color combination 108 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0)
+], "sanzo", "Sanzo Wada, Combination 108")
 loadcolorscheme(:sanzo_109, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
-    ], "sanzo", "Color combination 109 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117)
+], "sanzo", "Sanzo Wada, Combination 109")
 loadcolorscheme(:sanzo_110, [
-        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-    ], "sanzo", "Color combination 110 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392)
+], "sanzo", "Sanzo Wada, Combination 110")
 loadcolorscheme(:sanzo_111, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-    ], "sanzo", "Color combination 111 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196)
+], "sanzo", "Sanzo Wada, Combination 111")
 loadcolorscheme(:sanzo_112, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 112 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 112")
 loadcolorscheme(:sanzo_113, [
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-    ], "sanzo", "Color combination 113 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392)
+], "sanzo", "Sanzo Wada, Combination 113")
 loadcolorscheme(:sanzo_114, [
-        RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 114 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 114")
 loadcolorscheme(:sanzo_115, [
-        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-        RGB(1.0, 0.2, 0.09803921568627451),
-    ], "sanzo", "Color combination 115 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(1.0, 0.2, 0.09803921568627451)
+], "sanzo", "Sanzo Wada, Combination 115")
 loadcolorscheme(:sanzo_116, [
-        RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzo", "Color combination 116 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.2784313725490196, 0.2, 1.0)
+], "sanzo", "Sanzo Wada, Combination 116")
 loadcolorscheme(:sanzo_117, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 117 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 117")
 loadcolorscheme(:sanzo_118, [
-        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-    ], "sanzo", "Color combination 118 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392)
+], "sanzo", "Sanzo Wada, Combination 118")
 loadcolorscheme(:sanzo_119, [
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzo", "Color combination 119 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
+], "sanzo", "Sanzo Wada, Combination 119")
 loadcolorscheme(:sanzo_120, [
-        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
-    ], "sanzo", "Color combination 120 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294)
+], "sanzo", "Sanzo Wada, Combination 120")
 loadcolorscheme(:sanzo_121, [
-        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzo", "Color combination 121 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
+], "sanzo", "Sanzo Wada, Combination 121")
 loadcolorscheme(:sanzo_122, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzo", "Color combination 122 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
+], "sanzo", "Sanzo Wada, Combination 122")
 loadcolorscheme(:sanzo_123, [
-        RGB(1.0, 0.45098039215686275, 0.6),
+    RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzo", "Color combination 123 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
+], "sanzo", "Sanzo Wada, Combination 123")
 loadcolorscheme(:sanzo_124, [
-        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.6, 0.7019607843137254, 0.2),
-    ], "sanzo", "Color combination 124 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6, 0.7019607843137254, 0.2)
+], "sanzo", "Sanzo Wada, Combination 124")
 loadcolorscheme(:sanzo_125, [
-        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+    RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 125 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 125")
 loadcolorscheme(:sanzo_126, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzo", "Color combination 126 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.1411764705882353, 0.8)
+], "sanzo", "Sanzo Wada, Combination 126")
 loadcolorscheme(:sanzo_127, [
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
-        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
-    ], "sanzo", "Color combination 127 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177)
+], "sanzo", "Sanzo Wada, Combination 127")
 loadcolorscheme(:sanzo_128, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzo", "Color combination 128 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 128")
 loadcolorscheme(:sanzo_129, [
-        RGB(1.0, 0.9019607843137255, 0.0),
+    RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 129 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 129")
 loadcolorscheme(:sanzo_130, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 130 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 130")
 loadcolorscheme(:sanzo_131, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.0, 0.8117647058823529, 0.5686274509803921),
-    ], "sanzo", "Color combination 131 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.8117647058823529, 0.5686274509803921)
+], "sanzo", "Sanzo Wada, Combination 131")
 loadcolorscheme(:sanzo_132, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-    ], "sanzo", "Color combination 132 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744)
+], "sanzo", "Sanzo Wada, Combination 132")
 loadcolorscheme(:sanzo_133, [
-        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-        RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzo", "Color combination 133 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2, 1.0, 0.49019607843137253)
+], "sanzo", "Sanzo Wada, Combination 133")
 loadcolorscheme(:sanzo_134, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 134 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 134")
 loadcolorscheme(:sanzo_135, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 135 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 135")
 loadcolorscheme(:sanzo_136, [
-        RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
+    RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.09803921568627451, 0.8, 0.2),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 136 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 136")
 loadcolorscheme(:sanzo_137, [
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
-    ], "sanzo", "Color combination 137 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786)
+], "sanzo", "Sanzo Wada, Combination 137")
 loadcolorscheme(:sanzo_138, [
-        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzo", "Color combination 138 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
+], "sanzo", "Sanzo Wada, Combination 138")
 loadcolorscheme(:sanzo_139, [
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 139 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 139")
 loadcolorscheme(:sanzo_140, [
-        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 140 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 140")
 loadcolorscheme(:sanzo_141, [
-        RGB(1.0, 0.3215686274509804, 0.0),
+    RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzo", "Color combination 141 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
+], "sanzo", "Sanzo Wada, Combination 141")
 loadcolorscheme(:sanzo_142, [
-        RGB(0.6196078431372549, 0.09803921568627451, 0.30196078431372547),
+    RGB(0.6196078431372549, 0.09803921568627451, 0.30196078431372547),
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 142 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 142")
 loadcolorscheme(:sanzo_143, [
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    RGB(0.050980392156862744, 0.4588235294117647, 1.0),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzo", "Color combination 143 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 143")
 loadcolorscheme(:sanzo_144, [
-        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 144 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 144")
 loadcolorscheme(:sanzo_145, [
-        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzo", "Color combination 145 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
+], "sanzo", "Sanzo Wada, Combination 145")
 loadcolorscheme(:sanzo_146, [
-        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+    RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
-        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzo", "Color combination 146 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 146")
 loadcolorscheme(:sanzo_147, [
-        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+    RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzo", "Color combination 147 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 147")
 loadcolorscheme(:sanzo_148, [
-        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzo", "Color combination 148 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
+], "sanzo", "Sanzo Wada, Combination 148")
 loadcolorscheme(:sanzo_149, [
-        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzo", "Color combination 149 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
+], "sanzo", "Sanzo Wada, Combination 149")
 loadcolorscheme(:sanzo_150, [
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzo", "Color combination 150 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 150")
 loadcolorscheme(:sanzo_151, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(1.0, 0.5490196078431373, 0.0),
-    ], "sanzo", "Color combination 151 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(1.0, 0.5490196078431373, 0.0)
+], "sanzo", "Sanzo Wada, Combination 151")
 loadcolorscheme(:sanzo_152, [
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzo", "Color combination 152 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
+], "sanzo", "Sanzo Wada, Combination 152")
 loadcolorscheme(:sanzo_153, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(1.0, 0.6705882352941176, 0.0),
-    ], "sanzo", "Color combination 153 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.6705882352941176, 0.0)
+], "sanzo", "Sanzo Wada, Combination 153")
 loadcolorscheme(:sanzo_154, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 1.0, 0.0),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 154 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 154")
 loadcolorscheme(:sanzo_155, [
-        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzo", "Color combination 155 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
+], "sanzo", "Sanzo Wada, Combination 155")
 loadcolorscheme(:sanzo_156, [
-        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 156 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 156")
 loadcolorscheme(:sanzo_157, [
-        RGB(0.43529411764705883, 0.0, 0.2627450980392157),
+    RGB(0.43529411764705883, 0.0, 0.2627450980392157),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzo", "Color combination 157 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 157")
 loadcolorscheme(:sanzo_158, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzo", "Color combination 158 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.47843137254901963, 1.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 158")
 loadcolorscheme(:sanzo_159, [
-        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+    RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzo", "Color combination 159 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
+], "sanzo", "Sanzo Wada, Combination 159")
 loadcolorscheme(:sanzo_160, [
-        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+    RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-    ], "sanzo", "Color combination 160 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667)
+], "sanzo", "Sanzo Wada, Combination 160")
 loadcolorscheme(:sanzo_161, [
-        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzo", "Color combination 161 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
+], "sanzo", "Sanzo Wada, Combination 161")
 loadcolorscheme(:sanzo_162, [
-        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
-        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-    ], "sanzo", "Color combination 162 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803)
+], "sanzo", "Sanzo Wada, Combination 162")
 loadcolorscheme(:sanzo_163, [
-        RGB(1.0, 0.9019607843137255, 0.0),
+    RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 163 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 163")
 loadcolorscheme(:sanzo_164, [
-        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 164 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 164")
 loadcolorscheme(:sanzo_165, [
-        RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
-    ], "sanzo", "Color combination 165 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763)
+], "sanzo", "Sanzo Wada, Combination 165")
 loadcolorscheme(:sanzo_166, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzo", "Color combination 166 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
+], "sanzo", "Sanzo Wada, Combination 166")
 loadcolorscheme(:sanzo_167, [
-        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzo", "Color combination 167 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
+], "sanzo", "Sanzo Wada, Combination 167")
 loadcolorscheme(:sanzo_168, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-    ], "sanzo", "Color combination 168 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647)
+], "sanzo", "Sanzo Wada, Combination 168")
 loadcolorscheme(:sanzo_169, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzo", "Color combination 169 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 169")
 loadcolorscheme(:sanzo_170, [
-        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 170 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 170")
 loadcolorscheme(:sanzo_171, [
-        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzo", "Color combination 171 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 171")
 loadcolorscheme(:sanzo_172, [
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 172 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 172")
 loadcolorscheme(:sanzo_173, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzo", "Color combination 173 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 173")
 loadcolorscheme(:sanzo_174, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzo", "Color combination 174 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
+], "sanzo", "Sanzo Wada, Combination 174")
 loadcolorscheme(:sanzo_175, [
-        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+    RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
-        RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzo", "Color combination 175 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2784313725490196, 0.2, 1.0)
+], "sanzo", "Sanzo Wada, Combination 175")
 loadcolorscheme(:sanzo_176, [
-        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+    RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzo", "Color combination 176 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5019607843137255, 1.0, 0.8)
+], "sanzo", "Sanzo Wada, Combination 176")
 loadcolorscheme(:sanzo_177, [
-        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzo", "Color combination 177 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
+], "sanzo", "Sanzo Wada, Combination 177")
 loadcolorscheme(:sanzo_178, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzo", "Color combination 178 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 178")
 loadcolorscheme(:sanzo_179, [
-        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzo", "Color combination 179 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.1411764705882353, 0.8)
+], "sanzo", "Sanzo Wada, Combination 179")
 loadcolorscheme(:sanzo_180, [
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 180 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 180")
 loadcolorscheme(:sanzo_181, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzo", "Color combination 181 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
+], "sanzo", "Sanzo Wada, Combination 181")
 loadcolorscheme(:sanzo_182, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzo", "Color combination 182 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
+], "sanzo", "Sanzo Wada, Combination 182")
 loadcolorscheme(:sanzo_183, [
-        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
+    RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 183 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 183")
 loadcolorscheme(:sanzo_184, [
-        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+    RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
-    ], "sanzo", "Color combination 184 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765)
+], "sanzo", "Sanzo Wada, Combination 184")
 loadcolorscheme(:sanzo_185, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-    ], "sanzo", "Color combination 185 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 185")
 loadcolorscheme(:sanzo_186, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 186 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 186")
 loadcolorscheme(:sanzo_187, [
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzo", "Color combination 187 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 187")
 loadcolorscheme(:sanzo_188, [
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzo", "Color combination 188 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 188")
 loadcolorscheme(:sanzo_189, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzo", "Color combination 189 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
+], "sanzo", "Sanzo Wada, Combination 189")
 loadcolorscheme(:sanzo_190, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 190 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 190")
 loadcolorscheme(:sanzo_191, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 191 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 191")
 loadcolorscheme(:sanzo_192, [
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
-    ], "sanzo", "Color combination 192 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824)
+], "sanzo", "Sanzo Wada, Combination 192")
 loadcolorscheme(:sanzo_193, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
-    ], "sanzo", "Color combination 193 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156)
+], "sanzo", "Sanzo Wada, Combination 193")
 loadcolorscheme(:sanzo_194, [
-        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzo", "Color combination 194 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 194")
 loadcolorscheme(:sanzo_195, [
-        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+    RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 195 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 195")
 loadcolorscheme(:sanzo_196, [
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzo", "Color combination 196 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.2784313725490196, 0.2, 1.0)
+], "sanzo", "Sanzo Wada, Combination 196")
 loadcolorscheme(:sanzo_197, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 197 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 197")
 loadcolorscheme(:sanzo_198, [
-        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 198 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 198")
 loadcolorscheme(:sanzo_199, [
-        RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
+    RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
         RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
-        RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzo", "Color combination 199 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.1411764705882353, 0.8)
+], "sanzo", "Sanzo Wada, Combination 199")
 loadcolorscheme(:sanzo_200, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
-        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-    ], "sanzo", "Color combination 200 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353)
+], "sanzo", "Sanzo Wada, Combination 200")
 loadcolorscheme(:sanzo_201, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzo", "Color combination 201 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 201")
 loadcolorscheme(:sanzo_202, [
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 202 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 202")
 loadcolorscheme(:sanzo_203, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzo", "Color combination 203 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
+], "sanzo", "Sanzo Wada, Combination 203")
 loadcolorscheme(:sanzo_204, [
-        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzo", "Color combination 204 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
+], "sanzo", "Sanzo Wada, Combination 204")
 loadcolorscheme(:sanzo_205, [
-        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 205 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 205")
 loadcolorscheme(:sanzo_206, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-    ], "sanzo", "Color combination 206 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313)
+], "sanzo", "Sanzo Wada, Combination 206")
 loadcolorscheme(:sanzo_207, [
-        RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
+    RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 207 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 207")
 loadcolorscheme(:sanzo_208, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 208 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 208")
 loadcolorscheme(:sanzo_209, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 209 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 209")
 loadcolorscheme(:sanzo_210, [
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzo", "Color combination 210 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
+], "sanzo", "Sanzo Wada, Combination 210")
 loadcolorscheme(:sanzo_211, [
-        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+    RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.6, 0.7019607843137254, 0.2),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzo", "Color combination 211 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
+], "sanzo", "Sanzo Wada, Combination 211")
 loadcolorscheme(:sanzo_212, [
-        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 212 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 212")
 loadcolorscheme(:sanzo_213, [
-        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+    RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzo", "Color combination 213 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
+], "sanzo", "Sanzo Wada, Combination 213")
 loadcolorscheme(:sanzo_214, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 214 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 214")
 loadcolorscheme(:sanzo_215, [
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 215 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 215")
 loadcolorscheme(:sanzo_216, [
-        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 216 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 216")
 loadcolorscheme(:sanzo_217, [
-        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzo", "Color combination 217 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 217")
 loadcolorscheme(:sanzo_218, [
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
-    ], "sanzo", "Color combination 218 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824)
+], "sanzo", "Sanzo Wada, Combination 218")
 loadcolorscheme(:sanzo_219, [
-        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzo", "Color combination 219 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
+], "sanzo", "Sanzo Wada, Combination 219")
 loadcolorscheme(:sanzo_220, [
-        RGB(0.7254901960784313, 0.0, 0.47058823529411764),
+    RGB(0.7254901960784313, 0.0, 0.47058823529411764),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzo", "Color combination 220 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 220")
 loadcolorscheme(:sanzo_221, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 221 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 221")
 loadcolorscheme(:sanzo_222, [
-        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
-    ], "sanzo", "Color combination 222 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0)
+], "sanzo", "Sanzo Wada, Combination 222")
 loadcolorscheme(:sanzo_223, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzo", "Color combination 223 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 223")
 loadcolorscheme(:sanzo_224, [
-        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+    RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzo", "Color combination 224 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
+], "sanzo", "Sanzo Wada, Combination 224")
 loadcolorscheme(:sanzo_225, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
-    ], "sanzo", "Color combination 225 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902)
+], "sanzo", "Sanzo Wada, Combination 225")
 loadcolorscheme(:sanzo_226, [
-        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 226 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 226")
 loadcolorscheme(:sanzo_227, [
-        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+    RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzo", "Color combination 227 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
+], "sanzo", "Sanzo Wada, Combination 227")
 loadcolorscheme(:sanzo_228, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 228 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 228")
 loadcolorscheme(:sanzo_229, [
-        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 229 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 229")
 loadcolorscheme(:sanzo_230, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzo", "Color combination 230 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 230")
 loadcolorscheme(:sanzo_231, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzo", "Color combination 231 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 231")
 loadcolorscheme(:sanzo_232, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzo", "Color combination 232 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
+], "sanzo", "Sanzo Wada, Combination 232")
 loadcolorscheme(:sanzo_233, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 233 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 233")
 loadcolorscheme(:sanzo_234, [
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzo", "Color combination 234 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
+], "sanzo", "Sanzo Wada, Combination 234")
 loadcolorscheme(:sanzo_235, [
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzo", "Color combination 235 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
+], "sanzo", "Sanzo Wada, Combination 235")
 loadcolorscheme(:sanzo_236, [
-        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+    RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.0, 0.1411764705882353, 0.8),
-        RGB(0.4588235294117647, 0.25882352941176473, 0.3764705882352941),
-    ], "sanzo", "Color combination 236 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4588235294117647, 0.25882352941176473, 0.3764705882352941)
+], "sanzo", "Sanzo Wada, Combination 236")
 loadcolorscheme(:sanzo_237, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 237 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 237")
 loadcolorscheme(:sanzo_238, [
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+    RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzo", "Color combination 238 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 238")
 loadcolorscheme(:sanzo_239, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzo", "Color combination 239 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 239")
 loadcolorscheme(:sanzo_240, [
-        RGB(1.0, 0.47058823529411764, 0.5490196078431373),
+    RGB(1.0, 0.47058823529411764, 0.5490196078431373),
         RGB(1.0, 1.0, 0.0),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzo", "Color combination 240 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
+], "sanzo", "Sanzo Wada, Combination 240")
 loadcolorscheme(:sanzo_241, [
-        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-    ], "sanzo", "Color combination 241 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667)
+], "sanzo", "Sanzo Wada, Combination 241")
 loadcolorscheme(:sanzo_242, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 242 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 242")
 loadcolorscheme(:sanzo_243, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 243 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 243")
 loadcolorscheme(:sanzo_244, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
         RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 244 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 244")
 loadcolorscheme(:sanzo_245, [
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 245 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 245")
 loadcolorscheme(:sanzo_246, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
-    ], "sanzo", "Color combination 246 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786)
+], "sanzo", "Sanzo Wada, Combination 246")
 loadcolorscheme(:sanzo_247, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzo", "Color combination 247 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.1411764705882353, 0.8)
+], "sanzo", "Sanzo Wada, Combination 247")
 loadcolorscheme(:sanzo_248, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
-    ], "sanzo", "Color combination 248 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902)
+], "sanzo", "Sanzo Wada, Combination 248")
 loadcolorscheme(:sanzo_249, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-    ], "sanzo", "Color combination 249 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667)
+], "sanzo", "Sanzo Wada, Combination 249")
 loadcolorscheme(:sanzo_250, [
-        RGB(0.7686274509803922, 0.7490196078431373, 0.2),
+    RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzo", "Color combination 250 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 250")
 loadcolorscheme(:sanzo_251, [
-        RGB(0.6313725490196078, 0.0, 0.27058823529411763),
+    RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 251 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 251")
 loadcolorscheme(:sanzo_252, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzo", "Color combination 252 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 252")
 loadcolorscheme(:sanzo_253, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 253 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 253")
 loadcolorscheme(:sanzo_254, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
-    ], "sanzo", "Color combination 254 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 254")
 loadcolorscheme(:sanzo_255, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 255 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 255")
 loadcolorscheme(:sanzo_256, [
-        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+    RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.09803921568627451, 0.8, 0.2),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 256 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 256")
 loadcolorscheme(:sanzo_257, [
-        RGB(0.9490196078431372, 0.0, 0.0),
+    RGB(0.9490196078431372, 0.0, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzo", "Color combination 257 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 257")
 loadcolorscheme(:sanzo_258, [
-        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 258 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 258")
 loadcolorscheme(:sanzo_259, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzo", "Color combination 259 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 259")
 loadcolorscheme(:sanzo_260, [
-        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-        RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzo", "Color combination 260 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2, 1.0, 0.49019607843137253)
+], "sanzo", "Sanzo Wada, Combination 260")
 loadcolorscheme(:sanzo_261, [
-        RGB(0.6313725490196078, 0.0, 0.27058823529411763),
+    RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzo", "Color combination 261 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
+], "sanzo", "Sanzo Wada, Combination 261")
 loadcolorscheme(:sanzo_262, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzo", "Color combination 262 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 262")
 loadcolorscheme(:sanzo_263, [
-        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 263 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 263")
 loadcolorscheme(:sanzo_264, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzo", "Color combination 264 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
+], "sanzo", "Sanzo Wada, Combination 264")
 loadcolorscheme(:sanzo_265, [
-        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.6, 0.7019607843137254, 0.2),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzo", "Color combination 265 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
+], "sanzo", "Sanzo Wada, Combination 265")
 loadcolorscheme(:sanzo_266, [
-        RGB(0.9490196078431372, 0.0, 0.0),
+    RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzo", "Color combination 266 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
+], "sanzo", "Sanzo Wada, Combination 266")
 loadcolorscheme(:sanzo_267, [
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 267 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 267")
 loadcolorscheme(:sanzo_268, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzo", "Color combination 268 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 268")
 loadcolorscheme(:sanzo_269, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 269 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 269")
 loadcolorscheme(:sanzo_270, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzo", "Color combination 270 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 270")
 loadcolorscheme(:sanzo_271, [
-        RGB(0.7254901960784313, 0.0, 0.47058823529411764),
+    RGB(0.7254901960784313, 0.0, 0.47058823529411764),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzo", "Color combination 271 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
+], "sanzo", "Sanzo Wada, Combination 271")
 loadcolorscheme(:sanzo_272, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 272 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 272")
 loadcolorscheme(:sanzo_273, [
-        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+    RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(0.43529411764705883, 0.0, 0.2627450980392157),
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 273 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 273")
 loadcolorscheme(:sanzo_274, [
-        RGB(1.0, 0.2, 0.09803921568627451),
+    RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzo", "Color combination 274 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 274")
 loadcolorscheme(:sanzo_275, [
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzo", "Color combination 275 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
+], "sanzo", "Sanzo Wada, Combination 275")
 loadcolorscheme(:sanzo_276, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 276 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 276")
 loadcolorscheme(:sanzo_277, [
-        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+    RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzo", "Color combination 277 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
+], "sanzo", "Sanzo Wada, Combination 277")
 loadcolorscheme(:sanzo_278, [
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzo", "Color combination 278 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
+], "sanzo", "Sanzo Wada, Combination 278")
 loadcolorscheme(:sanzo_279, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzo", "Color combination 279 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
+], "sanzo", "Sanzo Wada, Combination 279")
 loadcolorscheme(:sanzo_280, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzo", "Color combination 280 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
+], "sanzo", "Sanzo Wada, Combination 280")
 loadcolorscheme(:sanzo_281, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 281 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 281")
 loadcolorscheme(:sanzo_282, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7607843137254902, 0.592156862745098, 0.35294117647058826),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-    ], "sanzo", "Color combination 282 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803)
+], "sanzo", "Sanzo Wada, Combination 282")
 loadcolorscheme(:sanzo_283, [
-        RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
+    RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzo", "Color combination 283 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
+], "sanzo", "Sanzo Wada, Combination 283")
 loadcolorscheme(:sanzo_284, [
-        RGB(0.9294117647058824, 0.23921568627450981, 0.4),
+    RGB(0.9294117647058824, 0.23921568627450981, 0.4),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.2, 1.0, 0.49019607843137253),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzo", "Color combination 284 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
+], "sanzo", "Sanzo Wada, Combination 284")
 loadcolorscheme(:sanzo_285, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.2, 0.09803921568627451),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzo", "Color combination 285 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 285")
 loadcolorscheme(:sanzo_286, [
-        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.8117647058823529, 0.5686274509803921),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 286 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 286")
 loadcolorscheme(:sanzo_287, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzo", "Color combination 287 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5019607843137255, 1.0, 0.8)
+], "sanzo", "Sanzo Wada, Combination 287")
 loadcolorscheme(:sanzo_288, [
-        RGB(1.0, 0.5490196078431373, 0.0),
+    RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.3137254901960784, 0.23921568627450981, 0.0),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 288 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 288")
 loadcolorscheme(:sanzo_289, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzo", "Color combination 289 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
+], "sanzo", "Sanzo Wada, Combination 289")
 loadcolorscheme(:sanzo_290, [
-        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzo", "Color combination 290 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 290")
 loadcolorscheme(:sanzo_291, [
-        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+    RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzo", "Color combination 291 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5019607843137255, 1.0, 0.8)
+], "sanzo", "Sanzo Wada, Combination 291")
 loadcolorscheme(:sanzo_292, [
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-    ], "sanzo", "Color combination 292 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412)
+], "sanzo", "Sanzo Wada, Combination 292")
 loadcolorscheme(:sanzo_293, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
-        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
-    ], "sanzo", "Color combination 293 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763)
+], "sanzo", "Sanzo Wada, Combination 293")
 loadcolorscheme(:sanzo_294, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 294 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 294")
 loadcolorscheme(:sanzo_295, [
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 1.0, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzo", "Color combination 295 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
+], "sanzo", "Sanzo Wada, Combination 295")
 loadcolorscheme(:sanzo_296, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 296 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 296")
 loadcolorscheme(:sanzo_297, [
-        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 297 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 297")
 loadcolorscheme(:sanzo_298, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(1.0, 0.2, 0.09803921568627451),
-    ], "sanzo", "Color combination 298 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(1.0, 0.2, 0.09803921568627451)
+], "sanzo", "Sanzo Wada, Combination 298")
 loadcolorscheme(:sanzo_299, [
-        RGB(0.8, 0.10196078431372549, 0.592156862745098),
+    RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 299 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 299")
 loadcolorscheme(:sanzo_300, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzo", "Color combination 300 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5019607843137255, 1.0, 0.8)
+], "sanzo", "Sanzo Wada, Combination 300")
 loadcolorscheme(:sanzo_301, [
-        RGB(0.9490196078431372, 0.0, 0.0),
+    RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzo", "Color combination 301 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
+], "sanzo", "Sanzo Wada, Combination 301")
 loadcolorscheme(:sanzo_302, [
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 302 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 302")
 loadcolorscheme(:sanzo_303, [
-        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+    RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 303 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 303")
 loadcolorscheme(:sanzo_304, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzo", "Color combination 304 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
+], "sanzo", "Sanzo Wada, Combination 304")
 loadcolorscheme(:sanzo_305, [
-        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+    RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzo", "Color combination 305 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 305")
 loadcolorscheme(:sanzo_306, [
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.09803921568627451, 0.8, 0.2),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzo", "Color combination 306 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 306")
 loadcolorscheme(:sanzo_307, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzo", "Color combination 307 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
+], "sanzo", "Sanzo Wada, Combination 307")
 loadcolorscheme(:sanzo_308, [
-        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+    RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzo", "Color combination 308 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 308")
 loadcolorscheme(:sanzo_309, [
-        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 309 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 309")
 loadcolorscheme(:sanzo_310, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-    ], "sanzo", "Color combination 310 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 310")
 loadcolorscheme(:sanzo_311, [
-        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
-        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
-    ], "sanzo", "Color combination 311 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725)
+], "sanzo", "Sanzo Wada, Combination 311")
 loadcolorscheme(:sanzo_312, [
-        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzo", "Color combination 312 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
+], "sanzo", "Sanzo Wada, Combination 312")
 loadcolorscheme(:sanzo_313, [
-        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 313 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 313")
 loadcolorscheme(:sanzo_314, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.0, 0.1411764705882353, 0.8),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzo", "Color combination 314 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
+], "sanzo", "Sanzo Wada, Combination 314")
 loadcolorscheme(:sanzo_315, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-    ], "sanzo", "Color combination 315 from Sanzo Wada's Dictionary of Color Combinations")
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804)
+], "sanzo", "Sanzo Wada, Combination 315")
 loadcolorscheme(:sanzo_316, [
-        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzo", "Color combination 316 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
+], "sanzo", "Sanzo Wada, Combination 316")
 loadcolorscheme(:sanzo_317, [
-        RGB(1.0, 0.7490196078431373, 0.6),
+    RGB(1.0, 0.7490196078431373, 0.6),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzo", "Color combination 317 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
+], "sanzo", "Sanzo Wada, Combination 317")
 loadcolorscheme(:sanzo_318, [
-        RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
+    RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzo", "Color combination 318 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
+], "sanzo", "Sanzo Wada, Combination 318")
 loadcolorscheme(:sanzo_319, [
-        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzo", "Color combination 319 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 319")
 loadcolorscheme(:sanzo_320, [
-        RGB(1.0, 0.45098039215686275, 0.6),
+    RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzo", "Color combination 320 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
+], "sanzo", "Sanzo Wada, Combination 320")
 loadcolorscheme(:sanzo_321, [
-        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzo", "Color combination 321 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
+], "sanzo", "Sanzo Wada, Combination 321")
 loadcolorscheme(:sanzo_322, [
-        RGB(0.9490196078431372, 0.0, 0.0),
+    RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
-        RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzo", "Color combination 322 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2784313725490196, 0.2, 1.0)
+], "sanzo", "Sanzo Wada, Combination 322")
 loadcolorscheme(:sanzo_323, [
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 323 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 323")
 loadcolorscheme(:sanzo_324, [
-        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzo", "Color combination 324 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
+], "sanzo", "Sanzo Wada, Combination 324")
 loadcolorscheme(:sanzo_325, [
-        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzo", "Color combination 325 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
+], "sanzo", "Sanzo Wada, Combination 325")
 loadcolorscheme(:sanzo_326, [
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzo", "Color combination 326 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.47843137254901963, 1.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 326")
 loadcolorscheme(:sanzo_327, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzo", "Color combination 327 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
+], "sanzo", "Sanzo Wada, Combination 327")
 loadcolorscheme(:sanzo_328, [
-        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+    RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
-        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
-    ], "sanzo", "Color combination 328 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156)
+], "sanzo", "Sanzo Wada, Combination 328")
 loadcolorscheme(:sanzo_329, [
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 329 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 329")
 loadcolorscheme(:sanzo_330, [
-        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+    RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzo", "Color combination 330 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
+], "sanzo", "Sanzo Wada, Combination 330")
 loadcolorscheme(:sanzo_331, [
-        RGB(0.8, 0.10196078431372549, 0.592156862745098),
+    RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzo", "Color combination 331 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
+], "sanzo", "Sanzo Wada, Combination 331")
 loadcolorscheme(:sanzo_332, [
-        RGB(1.0, 0.45098039215686275, 0.6),
+    RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzo", "Color combination 332 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
+], "sanzo", "Sanzo Wada, Combination 332")
 loadcolorscheme(:sanzo_333, [
-        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzo", "Color combination 333 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
+], "sanzo", "Sanzo Wada, Combination 333")
 loadcolorscheme(:sanzo_334, [
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzo", "Color combination 334 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
+], "sanzo", "Sanzo Wada, Combination 334")
 loadcolorscheme(:sanzo_335, [
-        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzo", "Color combination 335 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
+], "sanzo", "Sanzo Wada, Combination 335")
 loadcolorscheme(:sanzo_336, [
-        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
-    ], "sanzo", "Color combination 336 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117)
+], "sanzo", "Sanzo Wada, Combination 336")
 loadcolorscheme(:sanzo_337, [
-        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
         RGB(0.3254901960784314, 0.09019607843137255, 0.27058823529411763),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 337 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 337")
 loadcolorscheme(:sanzo_338, [
-        RGB(1.0, 0.6705882352941176, 0.0),
+    RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzo", "Color combination 338 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
+], "sanzo", "Sanzo Wada, Combination 338")
 loadcolorscheme(:sanzo_339, [
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+    RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzo", "Color combination 339 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
+], "sanzo", "Sanzo Wada, Combination 339")
 loadcolorscheme(:sanzo_340, [
-        RGB(1.0, 0.2, 0.09803921568627451),
+    RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 340 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 340")
 loadcolorscheme(:sanzo_341, [
-        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzo", "Color combination 341 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
+], "sanzo", "Sanzo Wada, Combination 341")
 loadcolorscheme(:sanzo_342, [
-        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
-        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-    ], "sanzo", "Color combination 342 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863)
+], "sanzo", "Sanzo Wada, Combination 342")
 loadcolorscheme(:sanzo_343, [
-        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
-    ], "sanzo", "Color combination 343 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433)
+], "sanzo", "Sanzo Wada, Combination 343")
 loadcolorscheme(:sanzo_344, [
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.0, 0.0, 0.0),
-    ], "sanzo", "Color combination 344 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.0, 0.0, 0.0)
+], "sanzo", "Sanzo Wada, Combination 344")
 loadcolorscheme(:sanzo_345, [
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-        RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzo", "Color combination 345 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.2784313725490196, 0.2, 1.0)
+], "sanzo", "Sanzo Wada, Combination 345")
 loadcolorscheme(:sanzo_346, [
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
-        RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
-    ], "sanzo", "Color combination 346 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275)
+], "sanzo", "Sanzo Wada, Combination 346")
 loadcolorscheme(:sanzo_347, [
-        RGB(0.6, 0.7019607843137254, 0.2),
+    RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-    ], "sanzo", "Color combination 347 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803)
+], "sanzo", "Sanzo Wada, Combination 347")
 loadcolorscheme(:sanzo_348, [
-        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+    RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzo", "Color combination 348 from Sanzo Wada's Dictionary of Color Combinations")
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
+], "sanzo", "Sanzo Wada, Combination 348")

--- a/data/sanzo.jl
+++ b/data/sanzo.jl
@@ -3,1701 +3,1701 @@
 loadcolorscheme(:sanzo_1, [
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzowada", "Color combination 1 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 1 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_2, [
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzowada", "Color combination 2 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 2 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_3, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-    ], "sanzowada", "Color combination 3 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 3 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_4, [
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 4 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 4 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_5, [
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzowada", "Color combination 5 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 5 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_6, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzowada", "Color combination 6 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 6 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_7, [
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzowada", "Color combination 7 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 7 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_8, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzowada", "Color combination 8 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 8 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_9, [
         RGB(0.23921568627450981, 0.0, 0.4745098039215686),
         RGB(0.43137254901960786, 0.4, 0.8313725490196079),
-    ], "sanzowada", "Color combination 9 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 9 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_10, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
-    ], "sanzowada", "Color combination 10 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 10 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_11, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
-    ], "sanzowada", "Color combination 11 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 11 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_12, [
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzowada", "Color combination 12 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 12 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_13, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-    ], "sanzowada", "Color combination 13 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 13 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_14, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-    ], "sanzowada", "Color combination 14 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 14 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_15, [
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzowada", "Color combination 15 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 15 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_16, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzowada", "Color combination 16 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 16 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_17, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzowada", "Color combination 17 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 17 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_18, [
         RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzowada", "Color combination 18 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 18 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_19, [
         RGB(0.3215686274509804, 0.12549019607843137, 0.0),
         RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzowada", "Color combination 19 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 19 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_20, [
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
-    ], "sanzowada", "Color combination 20 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 20 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_21, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzowada", "Color combination 21 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 21 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_22, [
         RGB(1.0, 1.0, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzowada", "Color combination 22 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 22 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_23, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzowada", "Color combination 23 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 23 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_24, [
         RGB(0.3137254901960784, 0.23921568627450981, 0.0),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-    ], "sanzowada", "Color combination 24 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 24 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_25, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzowada", "Color combination 25 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 25 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_26, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-    ], "sanzowada", "Color combination 26 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 26 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_27, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 27 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 27 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_28, [
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzowada", "Color combination 28 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 28 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_29, [
         RGB(0.4588235294117647, 0.5725490196078431, 0.2627450980392157),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 29 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 29 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_30, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
-    ], "sanzowada", "Color combination 30 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 30 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_31, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-    ], "sanzowada", "Color combination 31 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 31 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_32, [
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzowada", "Color combination 32 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 32 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_33, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 33 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 33 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_34, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 34 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 34 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_35, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-    ], "sanzowada", "Color combination 35 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 35 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_36, [
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzowada", "Color combination 36 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 36 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_37, [
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 37 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 37 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_38, [
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzowada", "Color combination 38 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 38 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_39, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzowada", "Color combination 39 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 39 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_40, [
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
-    ], "sanzowada", "Color combination 40 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 40 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_41, [
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzowada", "Color combination 41 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 41 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_42, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 42 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 42 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_43, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzowada", "Color combination 43 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 43 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_44, [
         RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzowada", "Color combination 44 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 44 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_45, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-    ], "sanzowada", "Color combination 45 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 45 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_46, [
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 46 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 46 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_47, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzowada", "Color combination 47 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 47 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_48, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzowada", "Color combination 48 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 48 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_49, [
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 49 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 49 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_50, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzowada", "Color combination 50 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 50 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_51, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 51 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 51 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_52, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 52 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 52 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_53, [
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzowada", "Color combination 53 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 53 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_54, [
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzowada", "Color combination 54 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 54 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_55, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(1.0, 1.0, 1.0),
-    ], "sanzowada", "Color combination 55 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 55 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_56, [
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 56 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 56 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_57, [
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 57 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 57 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_58, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzowada", "Color combination 58 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 58 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_59, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-    ], "sanzowada", "Color combination 59 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 59 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_60, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzowada", "Color combination 60 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 60 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_61, [
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzowada", "Color combination 61 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 61 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_62, [
         RGB(1.0, 1.0, 0.0),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 62 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 62 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_63, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzowada", "Color combination 63 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 63 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_64, [
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
-    ], "sanzowada", "Color combination 64 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 64 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_65, [
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzowada", "Color combination 65 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 65 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_66, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-    ], "sanzowada", "Color combination 66 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 66 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_67, [
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzowada", "Color combination 67 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 67 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_68, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(1.0, 1.0, 0.0),
-    ], "sanzowada", "Color combination 68 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 68 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_69, [
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 69 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 69 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_70, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzowada", "Color combination 70 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 70 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_71, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-    ], "sanzowada", "Color combination 71 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 71 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_72, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzowada", "Color combination 72 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 72 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_73, [
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-    ], "sanzowada", "Color combination 73 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 73 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_74, [
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzowada", "Color combination 74 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 74 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_75, [
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 75 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 75 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_76, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzowada", "Color combination 76 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 76 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_77, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
-    ], "sanzowada", "Color combination 77 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 77 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_78, [
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzowada", "Color combination 78 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 78 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_79, [
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzowada", "Color combination 79 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 79 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_80, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzowada", "Color combination 80 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 80 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_81, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzowada", "Color combination 81 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 81 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_82, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzowada", "Color combination 82 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 82 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_83, [
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 83 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 83 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_84, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzowada", "Color combination 84 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 84 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_85, [
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 85 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 85 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_86, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzowada", "Color combination 86 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 86 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_87, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-    ], "sanzowada", "Color combination 87 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 87 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_88, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 88 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 88 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_89, [
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 89 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 89 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_90, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzowada", "Color combination 90 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 90 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_91, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.7529411764705882, 0.3215686274509804, 0.0),
-    ], "sanzowada", "Color combination 91 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 91 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_92, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzowada", "Color combination 92 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 92 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_93, [
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzowada", "Color combination 93 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 93 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_94, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzowada", "Color combination 94 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 94 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_95, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzowada", "Color combination 95 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 95 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_96, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-    ], "sanzowada", "Color combination 96 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 96 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_97, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-    ], "sanzowada", "Color combination 97 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 97 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_98, [
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 98 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 98 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_99, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzowada", "Color combination 99 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 99 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_100, [
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
         RGB(0.43137254901960786, 0.4, 0.8313725490196079),
-    ], "sanzowada", "Color combination 100 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 100 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_101, [
         RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzowada", "Color combination 101 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 101 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_102, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.7529411764705882, 0.3215686274509804, 0.0),
-    ], "sanzowada", "Color combination 102 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 102 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_103, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzowada", "Color combination 103 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 103 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_104, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-    ], "sanzowada", "Color combination 104 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 104 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_105, [
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-    ], "sanzowada", "Color combination 105 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 105 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_106, [
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzowada", "Color combination 106 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 106 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_107, [
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
-    ], "sanzowada", "Color combination 107 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 107 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_108, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
-    ], "sanzowada", "Color combination 108 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 108 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_109, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
-    ], "sanzowada", "Color combination 109 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 109 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_110, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-    ], "sanzowada", "Color combination 110 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 110 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_111, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-    ], "sanzowada", "Color combination 111 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 111 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_112, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 112 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 112 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_113, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-    ], "sanzowada", "Color combination 113 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 113 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_114, [
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 114 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 114 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_115, [
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(1.0, 0.2, 0.09803921568627451),
-    ], "sanzowada", "Color combination 115 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 115 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_116, [
         RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzowada", "Color combination 116 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 116 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_117, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 117 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 117 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_118, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-    ], "sanzowada", "Color combination 118 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 118 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_119, [
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzowada", "Color combination 119 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 119 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_120, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
-    ], "sanzowada", "Color combination 120 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 120 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_121, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzowada", "Color combination 121 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 121 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_122, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzowada", "Color combination 122 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 122 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_123, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzowada", "Color combination 123 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 123 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_124, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.6, 0.7019607843137254, 0.2),
-    ], "sanzowada", "Color combination 124 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 124 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_125, [
         RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 125 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 125 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_126, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzowada", "Color combination 126 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 126 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_127, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
         RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
-    ], "sanzowada", "Color combination 127 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 127 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_128, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzowada", "Color combination 128 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 128 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_129, [
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 129 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 129 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_130, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 130 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 130 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_131, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.0, 0.8117647058823529, 0.5686274509803921),
-    ], "sanzowada", "Color combination 131 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 131 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_132, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-    ], "sanzowada", "Color combination 132 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 132 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_133, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
         RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzowada", "Color combination 133 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 133 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_134, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 134 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 134 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_135, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 135 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 135 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_136, [
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 136 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 136 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_137, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
-    ], "sanzowada", "Color combination 137 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 137 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_138, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzowada", "Color combination 138 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 138 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_139, [
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 139 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 139 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_140, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 140 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 140 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_141, [
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzowada", "Color combination 141 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 141 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_142, [
         RGB(0.6196078431372549, 0.09803921568627451, 0.30196078431372547),
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 142 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 142 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_143, [
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzowada", "Color combination 143 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 143 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_144, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 144 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 144 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_145, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzowada", "Color combination 145 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 145 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_146, [
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzowada", "Color combination 146 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 146 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_147, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzowada", "Color combination 147 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 147 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_148, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzowada", "Color combination 148 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 148 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_149, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzowada", "Color combination 149 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 149 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_150, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzowada", "Color combination 150 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 150 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_151, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.5490196078431373, 0.0),
-    ], "sanzowada", "Color combination 151 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 151 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_152, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzowada", "Color combination 152 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 152 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_153, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(1.0, 0.6705882352941176, 0.0),
-    ], "sanzowada", "Color combination 153 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 153 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_154, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 1.0, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 154 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 154 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_155, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzowada", "Color combination 155 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 155 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_156, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 156 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 156 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_157, [
         RGB(0.43529411764705883, 0.0, 0.2627450980392157),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzowada", "Color combination 157 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 157 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_158, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzowada", "Color combination 158 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 158 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_159, [
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzowada", "Color combination 159 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 159 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_160, [
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-    ], "sanzowada", "Color combination 160 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 160 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_161, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzowada", "Color combination 161 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 161 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_162, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-    ], "sanzowada", "Color combination 162 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 162 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_163, [
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 163 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 163 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_164, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 164 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 164 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_165, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
-    ], "sanzowada", "Color combination 165 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 165 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_166, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzowada", "Color combination 166 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 166 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_167, [
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzowada", "Color combination 167 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 167 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_168, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-    ], "sanzowada", "Color combination 168 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 168 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_169, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzowada", "Color combination 169 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 169 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_170, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 170 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 170 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_171, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzowada", "Color combination 171 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 171 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_172, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 172 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 172 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_173, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzowada", "Color combination 173 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 173 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_174, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzowada", "Color combination 174 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 174 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_175, [
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzowada", "Color combination 175 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 175 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_176, [
         RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzowada", "Color combination 176 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 176 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_177, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-    ], "sanzowada", "Color combination 177 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 177 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_178, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzowada", "Color combination 178 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 178 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_179, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzowada", "Color combination 179 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 179 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_180, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 180 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 180 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_181, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzowada", "Color combination 181 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 181 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_182, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzowada", "Color combination 182 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 182 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_183, [
         RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 183 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 183 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_184, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
-    ], "sanzowada", "Color combination 184 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 184 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_185, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-    ], "sanzowada", "Color combination 185 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 185 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_186, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 186 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 186 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_187, [
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzowada", "Color combination 187 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 187 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_188, [
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzowada", "Color combination 188 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 188 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_189, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzowada", "Color combination 189 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 189 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_190, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 190 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 190 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_191, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 191 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 191 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_192, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
         RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
-    ], "sanzowada", "Color combination 192 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 192 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_193, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
-    ], "sanzowada", "Color combination 193 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 193 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_194, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzowada", "Color combination 194 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 194 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_195, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 195 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 195 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_196, [
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzowada", "Color combination 196 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 196 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_197, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 197 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 197 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_198, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 198 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 198 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_199, [
         RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
         RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
         RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzowada", "Color combination 199 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 199 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_200, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-    ], "sanzowada", "Color combination 200 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 200 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_201, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzowada", "Color combination 201 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 201 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_202, [
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 202 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 202 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_203, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzowada", "Color combination 203 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 203 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_204, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzowada", "Color combination 204 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 204 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_205, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 205 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 205 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_206, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-    ], "sanzowada", "Color combination 206 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 206 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_207, [
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 207 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 207 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_208, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 208 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 208 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_209, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 209 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 209 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_210, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-    ], "sanzowada", "Color combination 210 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 210 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_211, [
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzowada", "Color combination 211 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 211 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_212, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 212 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 212 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_213, [
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzowada", "Color combination 213 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 213 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_214, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 214 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 214 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_215, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 215 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 215 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_216, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 216 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 216 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_217, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzowada", "Color combination 217 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 217 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_218, [
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
-    ], "sanzowada", "Color combination 218 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 218 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_219, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzowada", "Color combination 219 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 219 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_220, [
         RGB(0.7254901960784313, 0.0, 0.47058823529411764),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzowada", "Color combination 220 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 220 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_221, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 221 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 221 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_222, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.7529411764705882, 0.3215686274509804, 0.0),
-    ], "sanzowada", "Color combination 222 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 222 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_223, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzowada", "Color combination 223 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 223 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_224, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzowada", "Color combination 224 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 224 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_225, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
         RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
-    ], "sanzowada", "Color combination 225 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 225 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_226, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 226 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 226 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_227, [
         RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzowada", "Color combination 227 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 227 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_228, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 228 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 228 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_229, [
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 229 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 229 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_230, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzowada", "Color combination 230 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 230 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_231, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-    ], "sanzowada", "Color combination 231 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 231 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_232, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-    ], "sanzowada", "Color combination 232 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 232 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_233, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 233 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 233 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_234, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-    ], "sanzowada", "Color combination 234 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 234 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_235, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzowada", "Color combination 235 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 235 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_236, [
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.4588235294117647, 0.25882352941176473, 0.3764705882352941),
-    ], "sanzowada", "Color combination 236 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 236 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_237, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 237 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 237 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_238, [
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzowada", "Color combination 238 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 238 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_239, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-    ], "sanzowada", "Color combination 239 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 239 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_240, [
         RGB(1.0, 0.47058823529411764, 0.5490196078431373),
         RGB(1.0, 1.0, 0.0),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzowada", "Color combination 240 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 240 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_241, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-    ], "sanzowada", "Color combination 241 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 241 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_242, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 242 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 242 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_243, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 243 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 243 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_244, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
         RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 244 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 244 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_245, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 245 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 245 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_246, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
-    ], "sanzowada", "Color combination 246 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 246 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_247, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.0, 0.1411764705882353, 0.8),
-    ], "sanzowada", "Color combination 247 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 247 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_248, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
-    ], "sanzowada", "Color combination 248 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 248 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_249, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-    ], "sanzowada", "Color combination 249 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 249 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_250, [
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzowada", "Color combination 250 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 250 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_251, [
         RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 251 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 251 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_252, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzowada", "Color combination 252 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 252 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_253, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 253 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 253 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_254, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
-    ], "sanzowada", "Color combination 254 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 254 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_255, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 255 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 255 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_256, [
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 256 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 256 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_257, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzowada", "Color combination 257 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 257 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_258, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 258 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 258 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_259, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzowada", "Color combination 259 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 259 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_260, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
         RGB(0.2, 1.0, 0.49019607843137253),
-    ], "sanzowada", "Color combination 260 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 260 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_261, [
         RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-    ], "sanzowada", "Color combination 261 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 261 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_262, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzowada", "Color combination 262 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 262 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_263, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 263 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 263 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_264, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-    ], "sanzowada", "Color combination 264 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 264 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_265, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzowada", "Color combination 265 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 265 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_266, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzowada", "Color combination 266 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 266 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_267, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 267 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 267 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_268, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzowada", "Color combination 268 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 268 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_269, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 269 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 269 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_270, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzowada", "Color combination 270 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 270 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_271, [
         RGB(0.7254901960784313, 0.0, 0.47058823529411764),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzowada", "Color combination 271 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 271 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_272, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 272 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 272 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_273, [
         RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(0.43529411764705883, 0.0, 0.2627450980392157),
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 273 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 273 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_274, [
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-    ], "sanzowada", "Color combination 274 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 274 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_275, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzowada", "Color combination 275 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 275 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_276, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 276 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 276 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_277, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzowada", "Color combination 277 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 277 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_278, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzowada", "Color combination 278 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 278 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_279, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-    ], "sanzowada", "Color combination 279 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 279 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_280, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-    ], "sanzowada", "Color combination 280 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 280 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_281, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 281 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 281 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_282, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7607843137254902, 0.592156862745098, 0.35294117647058826),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-    ], "sanzowada", "Color combination 282 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 282 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_283, [
         RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-    ], "sanzowada", "Color combination 283 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 283 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_284, [
         RGB(0.9294117647058824, 0.23921568627450981, 0.4),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzowada", "Color combination 284 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 284 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_285, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzowada", "Color combination 285 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 285 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_286, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.8117647058823529, 0.5686274509803921),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 286 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 286 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_287, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzowada", "Color combination 287 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 287 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_288, [
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.3137254901960784, 0.23921568627450981, 0.0),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 288 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 288 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_289, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzowada", "Color combination 289 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 289 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_290, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzowada", "Color combination 290 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 290 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_291, [
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzowada", "Color combination 291 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 291 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_292, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-    ], "sanzowada", "Color combination 292 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 292 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_293, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
-    ], "sanzowada", "Color combination 293 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 293 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_294, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 294 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 294 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_295, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 1.0, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
-    ], "sanzowada", "Color combination 295 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 295 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_296, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 296 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 296 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_297, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 297 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 297 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_298, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(1.0, 0.2, 0.09803921568627451),
-    ], "sanzowada", "Color combination 298 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 298 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_299, [
         RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 299 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 299 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_300, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5019607843137255, 1.0, 0.8),
-    ], "sanzowada", "Color combination 300 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 300 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_301, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-    ], "sanzowada", "Color combination 301 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 301 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_302, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 302 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 302 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_303, [
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 303 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 303 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_304, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-    ], "sanzowada", "Color combination 304 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 304 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_305, [
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzowada", "Color combination 305 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 305 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_306, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-    ], "sanzowada", "Color combination 306 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 306 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_307, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzowada", "Color combination 307 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 307 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_308, [
         RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-    ], "sanzowada", "Color combination 308 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 308 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_309, [
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 309 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 309 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_310, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-    ], "sanzowada", "Color combination 310 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 310 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_311, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
-    ], "sanzowada", "Color combination 311 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 311 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_312, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-    ], "sanzowada", "Color combination 312 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 312 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_313, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 313 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 313 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_314, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
-    ], "sanzowada", "Color combination 314 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 314 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_315, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-    ], "sanzowada", "Color combination 315 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 315 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_316, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
-    ], "sanzowada", "Color combination 316 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 316 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_317, [
         RGB(1.0, 0.7490196078431373, 0.6),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-    ], "sanzowada", "Color combination 317 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 317 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_318, [
         RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzowada", "Color combination 318 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 318 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_319, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-    ], "sanzowada", "Color combination 319 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 319 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_320, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzowada", "Color combination 320 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 320 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_321, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-    ], "sanzowada", "Color combination 321 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 321 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_322, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzowada", "Color combination 322 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 322 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_323, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 323 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 323 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_324, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-    ], "sanzowada", "Color combination 324 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 324 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_325, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
-    ], "sanzowada", "Color combination 325 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 325 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_326, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.47843137254901963, 1.0, 0.0),
-    ], "sanzowada", "Color combination 326 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 326 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_327, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzowada", "Color combination 327 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 327 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_328, [
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
-    ], "sanzowada", "Color combination 328 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 328 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_329, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 329 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 329 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_330, [
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-    ], "sanzowada", "Color combination 330 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 330 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_331, [
         RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-    ], "sanzowada", "Color combination 331 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 331 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_332, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-    ], "sanzowada", "Color combination 332 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 332 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_333, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-    ], "sanzowada", "Color combination 333 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 333 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_334, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-    ], "sanzowada", "Color combination 334 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 334 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_335, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
-    ], "sanzowada", "Color combination 335 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 335 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_336, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
-    ], "sanzowada", "Color combination 336 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 336 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_337, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
         RGB(0.3254901960784314, 0.09019607843137255, 0.27058823529411763),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 337 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 337 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_338, [
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-    ], "sanzowada", "Color combination 338 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 338 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_339, [
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-    ], "sanzowada", "Color combination 339 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 339 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_340, [
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 340 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 340 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_341, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-    ], "sanzowada", "Color combination 341 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 341 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_342, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-    ], "sanzowada", "Color combination 342 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 342 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_343, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
-    ], "sanzowada", "Color combination 343 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 343 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_344, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.0, 0.0, 0.0),
-    ], "sanzowada", "Color combination 344 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 344 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_345, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
         RGB(0.2784313725490196, 0.2, 1.0),
-    ], "sanzowada", "Color combination 345 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 345 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_346, [
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
-    ], "sanzowada", "Color combination 346 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 346 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_347, [
         RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-    ], "sanzowada", "Color combination 347 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 347 from Sanzo Wada's Dictionary of Color Combinations")
 loadcolorscheme(:sanzo_348, [
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-    ], "sanzowada", "Color combination 348 from Sanzo Wada's Dictionary of Color Combinations")
+    ], "sanzo", "Color combination 348 from Sanzo Wada's Dictionary of Color Combinations")

--- a/data/sanzo.jl
+++ b/data/sanzo.jl
@@ -1,1699 +1,1701 @@
-loadcolorscheme(:sanzowada_1, [
+# Color combinations from Sanzo Wada's "A Dictionary of Color Combinations"
+
+loadcolorscheme(:sanzo_1, [
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
     ], "sanzowada", "Color combination 1 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_2, [
+loadcolorscheme(:sanzo_2, [
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
     ], "sanzowada", "Color combination 2 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_3, [
+loadcolorscheme(:sanzo_3, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
     ], "sanzowada", "Color combination 3 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_4, [
+loadcolorscheme(:sanzo_4, [
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 4 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_5, [
+loadcolorscheme(:sanzo_5, [
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
     ], "sanzowada", "Color combination 5 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_6, [
+loadcolorscheme(:sanzo_6, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
     ], "sanzowada", "Color combination 6 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_7, [
+loadcolorscheme(:sanzo_7, [
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
     ], "sanzowada", "Color combination 7 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_8, [
+loadcolorscheme(:sanzo_8, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
     ], "sanzowada", "Color combination 8 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_9, [
+loadcolorscheme(:sanzo_9, [
         RGB(0.23921568627450981, 0.0, 0.4745098039215686),
         RGB(0.43137254901960786, 0.4, 0.8313725490196079),
     ], "sanzowada", "Color combination 9 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_10, [
+loadcolorscheme(:sanzo_10, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
     ], "sanzowada", "Color combination 10 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_11, [
+loadcolorscheme(:sanzo_11, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
     ], "sanzowada", "Color combination 11 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_12, [
+loadcolorscheme(:sanzo_12, [
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
     ], "sanzowada", "Color combination 12 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_13, [
+loadcolorscheme(:sanzo_13, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
     ], "sanzowada", "Color combination 13 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_14, [
+loadcolorscheme(:sanzo_14, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
     ], "sanzowada", "Color combination 14 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_15, [
+loadcolorscheme(:sanzo_15, [
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
     ], "sanzowada", "Color combination 15 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_16, [
+loadcolorscheme(:sanzo_16, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
     ], "sanzowada", "Color combination 16 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_17, [
+loadcolorscheme(:sanzo_17, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.2, 1.0, 0.49019607843137253),
     ], "sanzowada", "Color combination 17 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_18, [
+loadcolorscheme(:sanzo_18, [
         RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
     ], "sanzowada", "Color combination 18 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_19, [
+loadcolorscheme(:sanzo_19, [
         RGB(0.3215686274509804, 0.12549019607843137, 0.0),
         RGB(0.47843137254901963, 1.0, 0.0),
     ], "sanzowada", "Color combination 19 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_20, [
+loadcolorscheme(:sanzo_20, [
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
     ], "sanzowada", "Color combination 20 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_21, [
+loadcolorscheme(:sanzo_21, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.2, 1.0, 0.49019607843137253),
     ], "sanzowada", "Color combination 21 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_22, [
+loadcolorscheme(:sanzo_22, [
         RGB(1.0, 1.0, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.0, 0.1411764705882353, 0.8),
     ], "sanzowada", "Color combination 22 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_23, [
+loadcolorscheme(:sanzo_23, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
     ], "sanzowada", "Color combination 23 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_24, [
+loadcolorscheme(:sanzo_24, [
         RGB(0.3137254901960784, 0.23921568627450981, 0.0),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
     ], "sanzowada", "Color combination 24 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_25, [
+loadcolorscheme(:sanzo_25, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
     ], "sanzowada", "Color combination 25 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_26, [
+loadcolorscheme(:sanzo_26, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
     ], "sanzowada", "Color combination 26 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_27, [
+loadcolorscheme(:sanzo_27, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 27 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_28, [
+loadcolorscheme(:sanzo_28, [
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
     ], "sanzowada", "Color combination 28 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_29, [
+loadcolorscheme(:sanzo_29, [
         RGB(0.4588235294117647, 0.5725490196078431, 0.2627450980392157),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 29 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_30, [
+loadcolorscheme(:sanzo_30, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
     ], "sanzowada", "Color combination 30 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_31, [
+loadcolorscheme(:sanzo_31, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
     ], "sanzowada", "Color combination 31 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_32, [
+loadcolorscheme(:sanzo_32, [
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.47843137254901963, 1.0, 0.0),
     ], "sanzowada", "Color combination 32 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_33, [
+loadcolorscheme(:sanzo_33, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 33 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_34, [
+loadcolorscheme(:sanzo_34, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 34 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_35, [
+loadcolorscheme(:sanzo_35, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
     ], "sanzowada", "Color combination 35 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_36, [
+loadcolorscheme(:sanzo_36, [
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
     ], "sanzowada", "Color combination 36 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_37, [
+loadcolorscheme(:sanzo_37, [
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 37 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_38, [
+loadcolorscheme(:sanzo_38, [
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.1411764705882353, 0.8),
     ], "sanzowada", "Color combination 38 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_39, [
+loadcolorscheme(:sanzo_39, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
     ], "sanzowada", "Color combination 39 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_40, [
+loadcolorscheme(:sanzo_40, [
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
     ], "sanzowada", "Color combination 40 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_41, [
+loadcolorscheme(:sanzo_41, [
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.5019607843137255, 1.0, 0.8),
     ], "sanzowada", "Color combination 41 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_42, [
+loadcolorscheme(:sanzo_42, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 42 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_43, [
+loadcolorscheme(:sanzo_43, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
     ], "sanzowada", "Color combination 43 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_44, [
+loadcolorscheme(:sanzo_44, [
         RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
     ], "sanzowada", "Color combination 44 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_45, [
+loadcolorscheme(:sanzo_45, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
     ], "sanzowada", "Color combination 45 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_46, [
+loadcolorscheme(:sanzo_46, [
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 46 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_47, [
+loadcolorscheme(:sanzo_47, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
     ], "sanzowada", "Color combination 47 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_48, [
+loadcolorscheme(:sanzo_48, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
     ], "sanzowada", "Color combination 48 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_49, [
+loadcolorscheme(:sanzo_49, [
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 49 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_50, [
+loadcolorscheme(:sanzo_50, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
     ], "sanzowada", "Color combination 50 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_51, [
+loadcolorscheme(:sanzo_51, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 51 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_52, [
+loadcolorscheme(:sanzo_52, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 52 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_53, [
+loadcolorscheme(:sanzo_53, [
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
     ], "sanzowada", "Color combination 53 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_54, [
+loadcolorscheme(:sanzo_54, [
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
     ], "sanzowada", "Color combination 54 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_55, [
+loadcolorscheme(:sanzo_55, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(1.0, 1.0, 1.0),
     ], "sanzowada", "Color combination 55 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_56, [
+loadcolorscheme(:sanzo_56, [
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 56 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_57, [
+loadcolorscheme(:sanzo_57, [
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 57 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_58, [
+loadcolorscheme(:sanzo_58, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.2, 1.0, 0.49019607843137253),
     ], "sanzowada", "Color combination 58 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_59, [
+loadcolorscheme(:sanzo_59, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
     ], "sanzowada", "Color combination 59 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_60, [
+loadcolorscheme(:sanzo_60, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
     ], "sanzowada", "Color combination 60 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_61, [
+loadcolorscheme(:sanzo_61, [
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
     ], "sanzowada", "Color combination 61 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_62, [
+loadcolorscheme(:sanzo_62, [
         RGB(1.0, 1.0, 0.0),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 62 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_63, [
+loadcolorscheme(:sanzo_63, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
     ], "sanzowada", "Color combination 63 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_64, [
+loadcolorscheme(:sanzo_64, [
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
     ], "sanzowada", "Color combination 64 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_65, [
+loadcolorscheme(:sanzo_65, [
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.5019607843137255, 1.0, 0.8),
     ], "sanzowada", "Color combination 65 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_66, [
+loadcolorscheme(:sanzo_66, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
     ], "sanzowada", "Color combination 66 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_67, [
+loadcolorscheme(:sanzo_67, [
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
     ], "sanzowada", "Color combination 67 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_68, [
+loadcolorscheme(:sanzo_68, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(1.0, 1.0, 0.0),
     ], "sanzowada", "Color combination 68 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_69, [
+loadcolorscheme(:sanzo_69, [
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 69 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_70, [
+loadcolorscheme(:sanzo_70, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
     ], "sanzowada", "Color combination 70 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_71, [
+loadcolorscheme(:sanzo_71, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
     ], "sanzowada", "Color combination 71 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_72, [
+loadcolorscheme(:sanzo_72, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
     ], "sanzowada", "Color combination 72 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_73, [
+loadcolorscheme(:sanzo_73, [
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
     ], "sanzowada", "Color combination 73 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_74, [
+loadcolorscheme(:sanzo_74, [
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
     ], "sanzowada", "Color combination 74 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_75, [
+loadcolorscheme(:sanzo_75, [
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 75 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_76, [
+loadcolorscheme(:sanzo_76, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
     ], "sanzowada", "Color combination 76 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_77, [
+loadcolorscheme(:sanzo_77, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
     ], "sanzowada", "Color combination 77 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_78, [
+loadcolorscheme(:sanzo_78, [
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
     ], "sanzowada", "Color combination 78 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_79, [
+loadcolorscheme(:sanzo_79, [
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
     ], "sanzowada", "Color combination 79 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_80, [
+loadcolorscheme(:sanzo_80, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
     ], "sanzowada", "Color combination 80 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_81, [
+loadcolorscheme(:sanzo_81, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
     ], "sanzowada", "Color combination 81 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_82, [
+loadcolorscheme(:sanzo_82, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
     ], "sanzowada", "Color combination 82 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_83, [
+loadcolorscheme(:sanzo_83, [
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 83 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_84, [
+loadcolorscheme(:sanzo_84, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
     ], "sanzowada", "Color combination 84 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_85, [
+loadcolorscheme(:sanzo_85, [
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 85 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_86, [
+loadcolorscheme(:sanzo_86, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.2, 1.0, 0.49019607843137253),
     ], "sanzowada", "Color combination 86 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_87, [
+loadcolorscheme(:sanzo_87, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
     ], "sanzowada", "Color combination 87 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_88, [
+loadcolorscheme(:sanzo_88, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 88 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_89, [
+loadcolorscheme(:sanzo_89, [
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 89 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_90, [
+loadcolorscheme(:sanzo_90, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
     ], "sanzowada", "Color combination 90 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_91, [
+loadcolorscheme(:sanzo_91, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.7529411764705882, 0.3215686274509804, 0.0),
     ], "sanzowada", "Color combination 91 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_92, [
+loadcolorscheme(:sanzo_92, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
     ], "sanzowada", "Color combination 92 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_93, [
+loadcolorscheme(:sanzo_93, [
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
     ], "sanzowada", "Color combination 93 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_94, [
+loadcolorscheme(:sanzo_94, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
     ], "sanzowada", "Color combination 94 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_95, [
+loadcolorscheme(:sanzo_95, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
     ], "sanzowada", "Color combination 95 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_96, [
+loadcolorscheme(:sanzo_96, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
     ], "sanzowada", "Color combination 96 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_97, [
+loadcolorscheme(:sanzo_97, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
     ], "sanzowada", "Color combination 97 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_98, [
+loadcolorscheme(:sanzo_98, [
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 98 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_99, [
+loadcolorscheme(:sanzo_99, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
     ], "sanzowada", "Color combination 99 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_100, [
+loadcolorscheme(:sanzo_100, [
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
         RGB(0.43137254901960786, 0.4, 0.8313725490196079),
     ], "sanzowada", "Color combination 100 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_101, [
+loadcolorscheme(:sanzo_101, [
         RGB(0.0, 0.1411764705882353, 0.8),
     ], "sanzowada", "Color combination 101 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_102, [
+loadcolorscheme(:sanzo_102, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.7529411764705882, 0.3215686274509804, 0.0),
     ], "sanzowada", "Color combination 102 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_103, [
+loadcolorscheme(:sanzo_103, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
     ], "sanzowada", "Color combination 103 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_104, [
+loadcolorscheme(:sanzo_104, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
     ], "sanzowada", "Color combination 104 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_105, [
+loadcolorscheme(:sanzo_105, [
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
     ], "sanzowada", "Color combination 105 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_106, [
+loadcolorscheme(:sanzo_106, [
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
     ], "sanzowada", "Color combination 106 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_107, [
+loadcolorscheme(:sanzo_107, [
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
     ], "sanzowada", "Color combination 107 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_108, [
+loadcolorscheme(:sanzo_108, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
     ], "sanzowada", "Color combination 108 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_109, [
+loadcolorscheme(:sanzo_109, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
     ], "sanzowada", "Color combination 109 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_110, [
+loadcolorscheme(:sanzo_110, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
     ], "sanzowada", "Color combination 110 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_111, [
+loadcolorscheme(:sanzo_111, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
     ], "sanzowada", "Color combination 111 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_112, [
+loadcolorscheme(:sanzo_112, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 112 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_113, [
+loadcolorscheme(:sanzo_113, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
     ], "sanzowada", "Color combination 113 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_114, [
+loadcolorscheme(:sanzo_114, [
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 114 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_115, [
+loadcolorscheme(:sanzo_115, [
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(1.0, 0.2, 0.09803921568627451),
     ], "sanzowada", "Color combination 115 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_116, [
+loadcolorscheme(:sanzo_116, [
         RGB(0.2784313725490196, 0.2, 1.0),
     ], "sanzowada", "Color combination 116 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_117, [
+loadcolorscheme(:sanzo_117, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 117 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_118, [
+loadcolorscheme(:sanzo_118, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
     ], "sanzowada", "Color combination 118 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_119, [
+loadcolorscheme(:sanzo_119, [
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
     ], "sanzowada", "Color combination 119 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_120, [
+loadcolorscheme(:sanzo_120, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
     ], "sanzowada", "Color combination 120 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_121, [
+loadcolorscheme(:sanzo_121, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
     ], "sanzowada", "Color combination 121 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_122, [
+loadcolorscheme(:sanzo_122, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
     ], "sanzowada", "Color combination 122 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_123, [
+loadcolorscheme(:sanzo_123, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
     ], "sanzowada", "Color combination 123 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_124, [
+loadcolorscheme(:sanzo_124, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.6, 0.7019607843137254, 0.2),
     ], "sanzowada", "Color combination 124 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_125, [
+loadcolorscheme(:sanzo_125, [
         RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 125 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_126, [
+loadcolorscheme(:sanzo_126, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.0, 0.1411764705882353, 0.8),
     ], "sanzowada", "Color combination 126 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_127, [
+loadcolorscheme(:sanzo_127, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
         RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
     ], "sanzowada", "Color combination 127 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_128, [
+loadcolorscheme(:sanzo_128, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
     ], "sanzowada", "Color combination 128 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_129, [
+loadcolorscheme(:sanzo_129, [
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 129 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_130, [
+loadcolorscheme(:sanzo_130, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 130 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_131, [
+loadcolorscheme(:sanzo_131, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.0, 0.8117647058823529, 0.5686274509803921),
     ], "sanzowada", "Color combination 131 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_132, [
+loadcolorscheme(:sanzo_132, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
     ], "sanzowada", "Color combination 132 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_133, [
+loadcolorscheme(:sanzo_133, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
         RGB(0.2, 1.0, 0.49019607843137253),
     ], "sanzowada", "Color combination 133 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_134, [
+loadcolorscheme(:sanzo_134, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 134 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_135, [
+loadcolorscheme(:sanzo_135, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 135 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_136, [
+loadcolorscheme(:sanzo_136, [
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 136 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_137, [
+loadcolorscheme(:sanzo_137, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
     ], "sanzowada", "Color combination 137 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_138, [
+loadcolorscheme(:sanzo_138, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
     ], "sanzowada", "Color combination 138 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_139, [
+loadcolorscheme(:sanzo_139, [
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 139 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_140, [
+loadcolorscheme(:sanzo_140, [
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 140 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_141, [
+loadcolorscheme(:sanzo_141, [
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
     ], "sanzowada", "Color combination 141 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_142, [
+loadcolorscheme(:sanzo_142, [
         RGB(0.6196078431372549, 0.09803921568627451, 0.30196078431372547),
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 142 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_143, [
+loadcolorscheme(:sanzo_143, [
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
     ], "sanzowada", "Color combination 143 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_144, [
+loadcolorscheme(:sanzo_144, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 144 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_145, [
+loadcolorscheme(:sanzo_145, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
     ], "sanzowada", "Color combination 145 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_146, [
+loadcolorscheme(:sanzo_146, [
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
     ], "sanzowada", "Color combination 146 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_147, [
+loadcolorscheme(:sanzo_147, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
     ], "sanzowada", "Color combination 147 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_148, [
+loadcolorscheme(:sanzo_148, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
     ], "sanzowada", "Color combination 148 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_149, [
+loadcolorscheme(:sanzo_149, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
     ], "sanzowada", "Color combination 149 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_150, [
+loadcolorscheme(:sanzo_150, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
     ], "sanzowada", "Color combination 150 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_151, [
+loadcolorscheme(:sanzo_151, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.5490196078431373, 0.0),
     ], "sanzowada", "Color combination 151 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_152, [
+loadcolorscheme(:sanzo_152, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
     ], "sanzowada", "Color combination 152 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_153, [
+loadcolorscheme(:sanzo_153, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(1.0, 0.6705882352941176, 0.0),
     ], "sanzowada", "Color combination 153 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_154, [
+loadcolorscheme(:sanzo_154, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 1.0, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 154 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_155, [
+loadcolorscheme(:sanzo_155, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
     ], "sanzowada", "Color combination 155 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_156, [
+loadcolorscheme(:sanzo_156, [
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 156 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_157, [
+loadcolorscheme(:sanzo_157, [
         RGB(0.43529411764705883, 0.0, 0.2627450980392157),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
     ], "sanzowada", "Color combination 157 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_158, [
+loadcolorscheme(:sanzo_158, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.47843137254901963, 1.0, 0.0),
     ], "sanzowada", "Color combination 158 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_159, [
+loadcolorscheme(:sanzo_159, [
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
     ], "sanzowada", "Color combination 159 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_160, [
+loadcolorscheme(:sanzo_160, [
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
     ], "sanzowada", "Color combination 160 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_161, [
+loadcolorscheme(:sanzo_161, [
         RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
     ], "sanzowada", "Color combination 161 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_162, [
+loadcolorscheme(:sanzo_162, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
     ], "sanzowada", "Color combination 162 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_163, [
+loadcolorscheme(:sanzo_163, [
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 163 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_164, [
+loadcolorscheme(:sanzo_164, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 164 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_165, [
+loadcolorscheme(:sanzo_165, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
     ], "sanzowada", "Color combination 165 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_166, [
+loadcolorscheme(:sanzo_166, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
     ], "sanzowada", "Color combination 166 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_167, [
+loadcolorscheme(:sanzo_167, [
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
     ], "sanzowada", "Color combination 167 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_168, [
+loadcolorscheme(:sanzo_168, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
     ], "sanzowada", "Color combination 168 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_169, [
+loadcolorscheme(:sanzo_169, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
     ], "sanzowada", "Color combination 169 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_170, [
+loadcolorscheme(:sanzo_170, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 170 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_171, [
+loadcolorscheme(:sanzo_171, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
     ], "sanzowada", "Color combination 171 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_172, [
+loadcolorscheme(:sanzo_172, [
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 172 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_173, [
+loadcolorscheme(:sanzo_173, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
     ], "sanzowada", "Color combination 173 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_174, [
+loadcolorscheme(:sanzo_174, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
     ], "sanzowada", "Color combination 174 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_175, [
+loadcolorscheme(:sanzo_175, [
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.2784313725490196, 0.2, 1.0),
     ], "sanzowada", "Color combination 175 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_176, [
+loadcolorscheme(:sanzo_176, [
         RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.5019607843137255, 1.0, 0.8),
     ], "sanzowada", "Color combination 176 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_177, [
+loadcolorscheme(:sanzo_177, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
     ], "sanzowada", "Color combination 177 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_178, [
+loadcolorscheme(:sanzo_178, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
     ], "sanzowada", "Color combination 178 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_179, [
+loadcolorscheme(:sanzo_179, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.0, 0.1411764705882353, 0.8),
     ], "sanzowada", "Color combination 179 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_180, [
+loadcolorscheme(:sanzo_180, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 180 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_181, [
+loadcolorscheme(:sanzo_181, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
     ], "sanzowada", "Color combination 181 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_182, [
+loadcolorscheme(:sanzo_182, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
     ], "sanzowada", "Color combination 182 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_183, [
+loadcolorscheme(:sanzo_183, [
         RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
         RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 183 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_184, [
+loadcolorscheme(:sanzo_184, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
     ], "sanzowada", "Color combination 184 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_185, [
+loadcolorscheme(:sanzo_185, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
     ], "sanzowada", "Color combination 185 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_186, [
+loadcolorscheme(:sanzo_186, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 186 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_187, [
+loadcolorscheme(:sanzo_187, [
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
     ], "sanzowada", "Color combination 187 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_188, [
+loadcolorscheme(:sanzo_188, [
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
     ], "sanzowada", "Color combination 188 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_189, [
+loadcolorscheme(:sanzo_189, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
     ], "sanzowada", "Color combination 189 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_190, [
+loadcolorscheme(:sanzo_190, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 190 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_191, [
+loadcolorscheme(:sanzo_191, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 191 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_192, [
+loadcolorscheme(:sanzo_192, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
         RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
     ], "sanzowada", "Color combination 192 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_193, [
+loadcolorscheme(:sanzo_193, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
     ], "sanzowada", "Color combination 193 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_194, [
+loadcolorscheme(:sanzo_194, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
     ], "sanzowada", "Color combination 194 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_195, [
+loadcolorscheme(:sanzo_195, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 195 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_196, [
+loadcolorscheme(:sanzo_196, [
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.2784313725490196, 0.2, 1.0),
     ], "sanzowada", "Color combination 196 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_197, [
+loadcolorscheme(:sanzo_197, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 197 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_198, [
+loadcolorscheme(:sanzo_198, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 198 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_199, [
+loadcolorscheme(:sanzo_199, [
         RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
         RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
         RGB(0.0, 0.1411764705882353, 0.8),
     ], "sanzowada", "Color combination 199 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_200, [
+loadcolorscheme(:sanzo_200, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
     ], "sanzowada", "Color combination 200 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_201, [
+loadcolorscheme(:sanzo_201, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
     ], "sanzowada", "Color combination 201 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_202, [
+loadcolorscheme(:sanzo_202, [
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 202 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_203, [
+loadcolorscheme(:sanzo_203, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
     ], "sanzowada", "Color combination 203 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_204, [
+loadcolorscheme(:sanzo_204, [
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
     ], "sanzowada", "Color combination 204 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_205, [
+loadcolorscheme(:sanzo_205, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 205 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_206, [
+loadcolorscheme(:sanzo_206, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
     ], "sanzowada", "Color combination 206 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_207, [
+loadcolorscheme(:sanzo_207, [
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 207 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_208, [
+loadcolorscheme(:sanzo_208, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 208 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_209, [
+loadcolorscheme(:sanzo_209, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 209 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_210, [
+loadcolorscheme(:sanzo_210, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
     ], "sanzowada", "Color combination 210 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_211, [
+loadcolorscheme(:sanzo_211, [
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
     ], "sanzowada", "Color combination 211 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_212, [
+loadcolorscheme(:sanzo_212, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 212 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_213, [
+loadcolorscheme(:sanzo_213, [
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
     ], "sanzowada", "Color combination 213 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_214, [
+loadcolorscheme(:sanzo_214, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 214 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_215, [
+loadcolorscheme(:sanzo_215, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 215 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_216, [
+loadcolorscheme(:sanzo_216, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 216 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_217, [
+loadcolorscheme(:sanzo_217, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
     ], "sanzowada", "Color combination 217 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_218, [
+loadcolorscheme(:sanzo_218, [
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
     ], "sanzowada", "Color combination 218 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_219, [
+loadcolorscheme(:sanzo_219, [
         RGB(0.9803921568627451, 0.16862745098039217, 0.0),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
     ], "sanzowada", "Color combination 219 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_220, [
+loadcolorscheme(:sanzo_220, [
         RGB(0.7254901960784313, 0.0, 0.47058823529411764),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
     ], "sanzowada", "Color combination 220 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_221, [
+loadcolorscheme(:sanzo_221, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 221 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_222, [
+loadcolorscheme(:sanzo_222, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.7529411764705882, 0.3215686274509804, 0.0),
     ], "sanzowada", "Color combination 222 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_223, [
+loadcolorscheme(:sanzo_223, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
     ], "sanzowada", "Color combination 223 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_224, [
+loadcolorscheme(:sanzo_224, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
     ], "sanzowada", "Color combination 224 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_225, [
+loadcolorscheme(:sanzo_225, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
         RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
     ], "sanzowada", "Color combination 225 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_226, [
+loadcolorscheme(:sanzo_226, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 226 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_227, [
+loadcolorscheme(:sanzo_227, [
         RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
     ], "sanzowada", "Color combination 227 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_228, [
+loadcolorscheme(:sanzo_228, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 228 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_229, [
+loadcolorscheme(:sanzo_229, [
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 229 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_230, [
+loadcolorscheme(:sanzo_230, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
     ], "sanzowada", "Color combination 230 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_231, [
+loadcolorscheme(:sanzo_231, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
     ], "sanzowada", "Color combination 231 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_232, [
+loadcolorscheme(:sanzo_232, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.0, 0.03137254901960784, 0.19215686274509805),
     ], "sanzowada", "Color combination 232 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_233, [
+loadcolorscheme(:sanzo_233, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 233 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_234, [
+loadcolorscheme(:sanzo_234, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
     ], "sanzowada", "Color combination 234 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_235, [
+loadcolorscheme(:sanzo_235, [
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
     ], "sanzowada", "Color combination 235 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_236, [
+loadcolorscheme(:sanzo_236, [
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.4588235294117647, 0.25882352941176473, 0.3764705882352941),
     ], "sanzowada", "Color combination 236 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_237, [
+loadcolorscheme(:sanzo_237, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 237 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_238, [
+loadcolorscheme(:sanzo_238, [
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
     ], "sanzowada", "Color combination 238 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_239, [
+loadcolorscheme(:sanzo_239, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
     ], "sanzowada", "Color combination 239 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_240, [
+loadcolorscheme(:sanzo_240, [
         RGB(1.0, 0.47058823529411764, 0.5490196078431373),
         RGB(1.0, 1.0, 0.0),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
     ], "sanzowada", "Color combination 240 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_241, [
+loadcolorscheme(:sanzo_241, [
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
     ], "sanzowada", "Color combination 241 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_242, [
+loadcolorscheme(:sanzo_242, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 242 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_243, [
+loadcolorscheme(:sanzo_243, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 243 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_244, [
+loadcolorscheme(:sanzo_244, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
         RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 244 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_245, [
+loadcolorscheme(:sanzo_245, [
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 245 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_246, [
+loadcolorscheme(:sanzo_246, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
     ], "sanzowada", "Color combination 246 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_247, [
+loadcolorscheme(:sanzo_247, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.0, 0.1411764705882353, 0.8),
     ], "sanzowada", "Color combination 247 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_248, [
+loadcolorscheme(:sanzo_248, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
     ], "sanzowada", "Color combination 248 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_249, [
+loadcolorscheme(:sanzo_249, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
     ], "sanzowada", "Color combination 249 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_250, [
+loadcolorscheme(:sanzo_250, [
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
     ], "sanzowada", "Color combination 250 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_251, [
+loadcolorscheme(:sanzo_251, [
         RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 251 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_252, [
+loadcolorscheme(:sanzo_252, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
     ], "sanzowada", "Color combination 252 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_253, [
+loadcolorscheme(:sanzo_253, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 253 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_254, [
+loadcolorscheme(:sanzo_254, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
     ], "sanzowada", "Color combination 254 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_255, [
+loadcolorscheme(:sanzo_255, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 255 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_256, [
+loadcolorscheme(:sanzo_256, [
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 256 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_257, [
+loadcolorscheme(:sanzo_257, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
     ], "sanzowada", "Color combination 257 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_258, [
+loadcolorscheme(:sanzo_258, [
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 258 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_259, [
+loadcolorscheme(:sanzo_259, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
     ], "sanzowada", "Color combination 259 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_260, [
+loadcolorscheme(:sanzo_260, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
         RGB(0.2, 1.0, 0.49019607843137253),
     ], "sanzowada", "Color combination 260 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_261, [
+loadcolorscheme(:sanzo_261, [
         RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.5019607843137255, 1.0, 0.8),
         RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
     ], "sanzowada", "Color combination 261 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_262, [
+loadcolorscheme(:sanzo_262, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
     ], "sanzowada", "Color combination 262 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_263, [
+loadcolorscheme(:sanzo_263, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 263 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_264, [
+loadcolorscheme(:sanzo_264, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
     ], "sanzowada", "Color combination 264 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_265, [
+loadcolorscheme(:sanzo_265, [
         RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
     ], "sanzowada", "Color combination 265 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_266, [
+loadcolorscheme(:sanzo_266, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
     ], "sanzowada", "Color combination 266 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_267, [
+loadcolorscheme(:sanzo_267, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 267 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_268, [
+loadcolorscheme(:sanzo_268, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
     ], "sanzowada", "Color combination 268 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_269, [
+loadcolorscheme(:sanzo_269, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 269 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_270, [
+loadcolorscheme(:sanzo_270, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
     ], "sanzowada", "Color combination 270 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_271, [
+loadcolorscheme(:sanzo_271, [
         RGB(0.7254901960784313, 0.0, 0.47058823529411764),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
     ], "sanzowada", "Color combination 271 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_272, [
+loadcolorscheme(:sanzo_272, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 272 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_273, [
+loadcolorscheme(:sanzo_273, [
         RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(0.43529411764705883, 0.0, 0.2627450980392157),
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 273 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_274, [
+loadcolorscheme(:sanzo_274, [
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
     ], "sanzowada", "Color combination 274 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_275, [
+loadcolorscheme(:sanzo_275, [
         RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
     ], "sanzowada", "Color combination 275 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_276, [
+loadcolorscheme(:sanzo_276, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 276 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_277, [
+loadcolorscheme(:sanzo_277, [
         RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
     ], "sanzowada", "Color combination 277 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_278, [
+loadcolorscheme(:sanzo_278, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
     ], "sanzowada", "Color combination 278 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_279, [
+loadcolorscheme(:sanzo_279, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
     ], "sanzowada", "Color combination 279 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_280, [
+loadcolorscheme(:sanzo_280, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
     ], "sanzowada", "Color combination 280 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_281, [
+loadcolorscheme(:sanzo_281, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 281 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_282, [
+loadcolorscheme(:sanzo_282, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7607843137254902, 0.592156862745098, 0.35294117647058826),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
     ], "sanzowada", "Color combination 282 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_283, [
+loadcolorscheme(:sanzo_283, [
         RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
     ], "sanzowada", "Color combination 283 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_284, [
+loadcolorscheme(:sanzo_284, [
         RGB(0.9294117647058824, 0.23921568627450981, 0.4),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
     ], "sanzowada", "Color combination 284 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_285, [
+loadcolorscheme(:sanzo_285, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
     ], "sanzowada", "Color combination 285 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_286, [
+loadcolorscheme(:sanzo_286, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.8117647058823529, 0.5686274509803921),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 286 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_287, [
+loadcolorscheme(:sanzo_287, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
         RGB(0.5019607843137255, 1.0, 0.8),
     ], "sanzowada", "Color combination 287 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_288, [
+loadcolorscheme(:sanzo_288, [
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.3137254901960784, 0.23921568627450981, 0.0),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 288 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_289, [
+loadcolorscheme(:sanzo_289, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
     ], "sanzowada", "Color combination 289 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_290, [
+loadcolorscheme(:sanzo_290, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
     ], "sanzowada", "Color combination 290 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_291, [
+loadcolorscheme(:sanzo_291, [
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.5019607843137255, 1.0, 0.8),
     ], "sanzowada", "Color combination 291 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_292, [
+loadcolorscheme(:sanzo_292, [
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
     ], "sanzowada", "Color combination 292 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_293, [
+loadcolorscheme(:sanzo_293, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
         RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
     ], "sanzowada", "Color combination 293 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_294, [
+loadcolorscheme(:sanzo_294, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 294 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_295, [
+loadcolorscheme(:sanzo_295, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 1.0, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
     ], "sanzowada", "Color combination 295 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_296, [
+loadcolorscheme(:sanzo_296, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 296 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_297, [
+loadcolorscheme(:sanzo_297, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 297 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_298, [
+loadcolorscheme(:sanzo_298, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(1.0, 0.2, 0.09803921568627451),
     ], "sanzowada", "Color combination 298 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_299, [
+loadcolorscheme(:sanzo_299, [
         RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 299 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_300, [
+loadcolorscheme(:sanzo_300, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.5019607843137255, 1.0, 0.8),
     ], "sanzowada", "Color combination 300 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_301, [
+loadcolorscheme(:sanzo_301, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
     ], "sanzowada", "Color combination 301 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_302, [
+loadcolorscheme(:sanzo_302, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 302 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_303, [
+loadcolorscheme(:sanzo_303, [
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 303 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_304, [
+loadcolorscheme(:sanzo_304, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
     ], "sanzowada", "Color combination 304 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_305, [
+loadcolorscheme(:sanzo_305, [
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
     ], "sanzowada", "Color combination 305 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_306, [
+loadcolorscheme(:sanzo_306, [
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
     ], "sanzowada", "Color combination 306 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_307, [
+loadcolorscheme(:sanzo_307, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
     ], "sanzowada", "Color combination 307 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_308, [
+loadcolorscheme(:sanzo_308, [
         RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
     ], "sanzowada", "Color combination 308 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_309, [
+loadcolorscheme(:sanzo_309, [
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 309 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_310, [
+loadcolorscheme(:sanzo_310, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
     ], "sanzowada", "Color combination 310 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_311, [
+loadcolorscheme(:sanzo_311, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
     ], "sanzowada", "Color combination 311 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_312, [
+loadcolorscheme(:sanzo_312, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
     ], "sanzowada", "Color combination 312 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_313, [
+loadcolorscheme(:sanzo_313, [
         RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 313 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_314, [
+loadcolorscheme(:sanzo_314, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.17647058823529413, 0.0, 0.3764705882352941),
     ], "sanzowada", "Color combination 314 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_315, [
+loadcolorscheme(:sanzo_315, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
     ], "sanzowada", "Color combination 315 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_316, [
+loadcolorscheme(:sanzo_316, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
         RGB(0.20392156862745098, 0.0, 0.6392156862745098),
     ], "sanzowada", "Color combination 316 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_317, [
+loadcolorscheme(:sanzo_317, [
         RGB(1.0, 0.7490196078431373, 0.6),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
     ], "sanzowada", "Color combination 317 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_318, [
+loadcolorscheme(:sanzo_318, [
         RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
     ], "sanzowada", "Color combination 318 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_319, [
+loadcolorscheme(:sanzo_319, [
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
     ], "sanzowada", "Color combination 319 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_320, [
+loadcolorscheme(:sanzo_320, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
     ], "sanzowada", "Color combination 320 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_321, [
+loadcolorscheme(:sanzo_321, [
         RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
     ], "sanzowada", "Color combination 321 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_322, [
+loadcolorscheme(:sanzo_322, [
         RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.2784313725490196, 0.2, 1.0),
     ], "sanzowada", "Color combination 322 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_323, [
+loadcolorscheme(:sanzo_323, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 323 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_324, [
+loadcolorscheme(:sanzo_324, [
         RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
     ], "sanzowada", "Color combination 324 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_325, [
+loadcolorscheme(:sanzo_325, [
         RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
         RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
     ], "sanzowada", "Color combination 325 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_326, [
+loadcolorscheme(:sanzo_326, [
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.47843137254901963, 1.0, 0.0),
     ], "sanzowada", "Color combination 326 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_327, [
+loadcolorscheme(:sanzo_327, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
     ], "sanzowada", "Color combination 327 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_328, [
+loadcolorscheme(:sanzo_328, [
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
     ], "sanzowada", "Color combination 328 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_329, [
+loadcolorscheme(:sanzo_329, [
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 329 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_330, [
+loadcolorscheme(:sanzo_330, [
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
     ], "sanzowada", "Color combination 330 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_331, [
+loadcolorscheme(:sanzo_331, [
         RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
     ], "sanzowada", "Color combination 331 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_332, [
+loadcolorscheme(:sanzo_332, [
         RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
     ], "sanzowada", "Color combination 332 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_333, [
+loadcolorscheme(:sanzo_333, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
     ], "sanzowada", "Color combination 333 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_334, [
+loadcolorscheme(:sanzo_334, [
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
         RGB(0.0, 0.5411764705882353, 0.6313725490196078),
     ], "sanzowada", "Color combination 334 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_335, [
+loadcolorscheme(:sanzo_335, [
         RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
         RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
     ], "sanzowada", "Color combination 335 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_336, [
+loadcolorscheme(:sanzo_336, [
         RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
     ], "sanzowada", "Color combination 336 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_337, [
+loadcolorscheme(:sanzo_337, [
         RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
         RGB(0.3254901960784314, 0.09019607843137255, 0.27058823529411763),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 337 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_338, [
+loadcolorscheme(:sanzo_338, [
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
     ], "sanzowada", "Color combination 338 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_339, [
+loadcolorscheme(:sanzo_339, [
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
     ], "sanzowada", "Color combination 339 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_340, [
+loadcolorscheme(:sanzo_340, [
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 340 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_341, [
+loadcolorscheme(:sanzo_341, [
         RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
     ], "sanzowada", "Color combination 341 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_342, [
+loadcolorscheme(:sanzo_342, [
         RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
     ], "sanzowada", "Color combination 342 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_343, [
+loadcolorscheme(:sanzo_343, [
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
     ], "sanzowada", "Color combination 343 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_344, [
+loadcolorscheme(:sanzo_344, [
         RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
         RGB(0.0, 0.0, 0.0),
     ], "sanzowada", "Color combination 344 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_345, [
+loadcolorscheme(:sanzo_345, [
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
         RGB(0.2784313725490196, 0.2, 1.0),
     ], "sanzowada", "Color combination 345 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_346, [
+loadcolorscheme(:sanzo_346, [
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
     ], "sanzowada", "Color combination 346 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_347, [
+loadcolorscheme(:sanzo_347, [
         RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
         RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
     ], "sanzowada", "Color combination 347 from Sanzo Wada's Dictionary of Color Combinations")
-loadcolorscheme(:sanzowada_348, [
+loadcolorscheme(:sanzo_348, [
         RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),

--- a/data/sanzo.jl
+++ b/data/sanzo.jl
@@ -1,1701 +1,1701 @@
-loadcolorscheme(:sanzo_1, [
-    RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
-], "sanzo", "Sanzo Wada, Combination 1")
-loadcolorscheme(:sanzo_2, [
-    RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
-], "sanzo", "Sanzo Wada, Combination 2")
-loadcolorscheme(:sanzo_3, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 3")
-loadcolorscheme(:sanzo_4, [
-    RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 4")
-loadcolorscheme(:sanzo_5, [
-    RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 5")
-loadcolorscheme(:sanzo_6, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
-], "sanzo", "Sanzo Wada, Combination 6")
-loadcolorscheme(:sanzo_7, [
-    RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 7")
-loadcolorscheme(:sanzo_8, [
-    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
-], "sanzo", "Sanzo Wada, Combination 8")
-loadcolorscheme(:sanzo_9, [
-    RGB(0.23921568627450981, 0.0, 0.4745098039215686),
-        RGB(0.43137254901960786, 0.4, 0.8313725490196079)
-], "sanzo", "Sanzo Wada, Combination 9")
-loadcolorscheme(:sanzo_10, [
-    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157)
-], "sanzo", "Sanzo Wada, Combination 10")
-loadcolorscheme(:sanzo_11, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745)
-], "sanzo", "Sanzo Wada, Combination 11")
-loadcolorscheme(:sanzo_12, [
-    RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 12")
-loadcolorscheme(:sanzo_13, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647)
-], "sanzo", "Sanzo Wada, Combination 13")
-loadcolorscheme(:sanzo_14, [
-    RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902)
-], "sanzo", "Sanzo Wada, Combination 14")
-loadcolorscheme(:sanzo_15, [
-    RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
-], "sanzo", "Sanzo Wada, Combination 15")
-loadcolorscheme(:sanzo_16, [
-    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
-], "sanzo", "Sanzo Wada, Combination 16")
-loadcolorscheme(:sanzo_17, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
-        RGB(0.2, 1.0, 0.49019607843137253)
-], "sanzo", "Sanzo Wada, Combination 17")
-loadcolorscheme(:sanzo_18, [
-    RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+loadcolorscheme(:sanzo_001, [
+        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 1")
+loadcolorscheme(:sanzo_002, [
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 2")
+loadcolorscheme(:sanzo_003, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 3")
+loadcolorscheme(:sanzo_004, [
+        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 4")
+loadcolorscheme(:sanzo_005, [
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 5")
+loadcolorscheme(:sanzo_006, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzo", "Sanzo Wada, Combination 6")
+loadcolorscheme(:sanzo_007, [
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 7")
+loadcolorscheme(:sanzo_008, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 8")
+loadcolorscheme(:sanzo_009, [
+        RGB(0.23921568627450981, 0.0, 0.4745098039215686),
+        RGB(0.43137254901960786, 0.4, 0.8313725490196079),
+    ], "sanzo", "Sanzo Wada, Combination 9")
+loadcolorscheme(:sanzo_010, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
+    ], "sanzo", "Sanzo Wada, Combination 10")
+loadcolorscheme(:sanzo_011, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
+    ], "sanzo", "Sanzo Wada, Combination 11")
+loadcolorscheme(:sanzo_012, [
+        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 12")
+loadcolorscheme(:sanzo_013, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 13")
+loadcolorscheme(:sanzo_014, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 14")
+loadcolorscheme(:sanzo_015, [
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 15")
+loadcolorscheme(:sanzo_016, [
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzo", "Sanzo Wada, Combination 16")
+loadcolorscheme(:sanzo_017, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzo", "Sanzo Wada, Combination 17")
+loadcolorscheme(:sanzo_018, [
+        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
-], "sanzo", "Sanzo Wada, Combination 18")
-loadcolorscheme(:sanzo_19, [
-    RGB(0.3215686274509804, 0.12549019607843137, 0.0),
-        RGB(0.47843137254901963, 1.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 19")
-loadcolorscheme(:sanzo_20, [
-    RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.8, 0.5215686274509804, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 20")
-loadcolorscheme(:sanzo_21, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.2, 1.0, 0.49019607843137253)
-], "sanzo", "Sanzo Wada, Combination 21")
-loadcolorscheme(:sanzo_22, [
-    RGB(1.0, 1.0, 0.0),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 18")
+loadcolorscheme(:sanzo_019, [
+        RGB(0.3215686274509804, 0.12549019607843137, 0.0),
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 19")
+loadcolorscheme(:sanzo_020, [
+        RGB(0.5019607843137255, 1.0, 0.8),
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 20")
+loadcolorscheme(:sanzo_021, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzo", "Sanzo Wada, Combination 21")
+loadcolorscheme(:sanzo_022, [
+        RGB(1.0, 1.0, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.0, 0.1411764705882353, 0.8)
-], "sanzo", "Sanzo Wada, Combination 22")
-loadcolorscheme(:sanzo_23, [
-    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 22")
+loadcolorscheme(:sanzo_023, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 23")
-loadcolorscheme(:sanzo_24, [
-    RGB(0.3137254901960784, 0.23921568627450981, 0.0),
-        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647)
-], "sanzo", "Sanzo Wada, Combination 24")
-loadcolorscheme(:sanzo_25, [
-    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 25")
-loadcolorscheme(:sanzo_26, [
-    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255)
-], "sanzo", "Sanzo Wada, Combination 26")
-loadcolorscheme(:sanzo_27, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 27")
-loadcolorscheme(:sanzo_28, [
-    RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
-], "sanzo", "Sanzo Wada, Combination 28")
-loadcolorscheme(:sanzo_29, [
-    RGB(0.4588235294117647, 0.5725490196078431, 0.2627450980392157),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 29")
-loadcolorscheme(:sanzo_30, [
-    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
-        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745)
-], "sanzo", "Sanzo Wada, Combination 30")
-loadcolorscheme(:sanzo_31, [
-    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 31")
-loadcolorscheme(:sanzo_32, [
-    RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.47843137254901963, 1.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 32")
-loadcolorscheme(:sanzo_33, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 33")
-loadcolorscheme(:sanzo_34, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 34")
-loadcolorscheme(:sanzo_35, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
-        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217)
-], "sanzo", "Sanzo Wada, Combination 35")
-loadcolorscheme(:sanzo_36, [
-    RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 36")
-loadcolorscheme(:sanzo_37, [
-    RGB(0.6392156862745098, 0.12941176470588237, 0.0),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 37")
-loadcolorscheme(:sanzo_38, [
-    RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.1411764705882353, 0.8)
-], "sanzo", "Sanzo Wada, Combination 38")
-loadcolorscheme(:sanzo_39, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
-], "sanzo", "Sanzo Wada, Combination 39")
-loadcolorscheme(:sanzo_40, [
-    RGB(0.7803921568627451, 0.2627450980392157, 0.0)
-], "sanzo", "Sanzo Wada, Combination 40")
-loadcolorscheme(:sanzo_41, [
-    RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
-        RGB(0.5019607843137255, 1.0, 0.8)
-], "sanzo", "Sanzo Wada, Combination 41")
-loadcolorscheme(:sanzo_42, [
-    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 42")
-loadcolorscheme(:sanzo_43, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 43")
-loadcolorscheme(:sanzo_44, [
-    RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 44")
-loadcolorscheme(:sanzo_45, [
-    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725)
-], "sanzo", "Sanzo Wada, Combination 45")
-loadcolorscheme(:sanzo_46, [
-    RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 46")
-loadcolorscheme(:sanzo_47, [
-    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
-], "sanzo", "Sanzo Wada, Combination 47")
-loadcolorscheme(:sanzo_48, [
-    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
-], "sanzo", "Sanzo Wada, Combination 48")
-loadcolorscheme(:sanzo_49, [
-    RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 49")
-loadcolorscheme(:sanzo_50, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
-], "sanzo", "Sanzo Wada, Combination 50")
-loadcolorscheme(:sanzo_51, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 51")
-loadcolorscheme(:sanzo_52, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 52")
-loadcolorscheme(:sanzo_53, [
-    RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
-], "sanzo", "Sanzo Wada, Combination 53")
-loadcolorscheme(:sanzo_54, [
-    RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
-], "sanzo", "Sanzo Wada, Combination 54")
-loadcolorscheme(:sanzo_55, [
-    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
-        RGB(1.0, 1.0, 1.0)
-], "sanzo", "Sanzo Wada, Combination 55")
-loadcolorscheme(:sanzo_56, [
-    RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 56")
-loadcolorscheme(:sanzo_57, [
-    RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 57")
-loadcolorscheme(:sanzo_58, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.2, 1.0, 0.49019607843137253)
-], "sanzo", "Sanzo Wada, Combination 58")
-loadcolorscheme(:sanzo_59, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744)
-], "sanzo", "Sanzo Wada, Combination 59")
-loadcolorscheme(:sanzo_60, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
-], "sanzo", "Sanzo Wada, Combination 60")
-loadcolorscheme(:sanzo_61, [
-    RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
-], "sanzo", "Sanzo Wada, Combination 61")
-loadcolorscheme(:sanzo_62, [
-    RGB(1.0, 1.0, 0.0),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 62")
-loadcolorscheme(:sanzo_63, [
-    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
-], "sanzo", "Sanzo Wada, Combination 63")
-loadcolorscheme(:sanzo_64, [
-    RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177)
-], "sanzo", "Sanzo Wada, Combination 64")
-loadcolorscheme(:sanzo_65, [
-    RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.5019607843137255, 1.0, 0.8)
-], "sanzo", "Sanzo Wada, Combination 65")
-loadcolorscheme(:sanzo_66, [
-    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941)
-], "sanzo", "Sanzo Wada, Combination 66")
-loadcolorscheme(:sanzo_67, [
-    RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
-], "sanzo", "Sanzo Wada, Combination 67")
-loadcolorscheme(:sanzo_68, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
-        RGB(1.0, 1.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 68")
-loadcolorscheme(:sanzo_69, [
-    RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 69")
-loadcolorscheme(:sanzo_70, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
-], "sanzo", "Sanzo Wada, Combination 70")
-loadcolorscheme(:sanzo_71, [
-    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275)
-], "sanzo", "Sanzo Wada, Combination 71")
-loadcolorscheme(:sanzo_72, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
-], "sanzo", "Sanzo Wada, Combination 72")
-loadcolorscheme(:sanzo_73, [
-    RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255)
-], "sanzo", "Sanzo Wada, Combination 73")
-loadcolorscheme(:sanzo_74, [
-    RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 74")
-loadcolorscheme(:sanzo_75, [
-    RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 75")
-loadcolorscheme(:sanzo_76, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 76")
-loadcolorscheme(:sanzo_77, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275)
-], "sanzo", "Sanzo Wada, Combination 77")
-loadcolorscheme(:sanzo_78, [
-    RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
-], "sanzo", "Sanzo Wada, Combination 78")
-loadcolorscheme(:sanzo_79, [
-    RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 79")
-loadcolorscheme(:sanzo_80, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 80")
-loadcolorscheme(:sanzo_81, [
-    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 81")
-loadcolorscheme(:sanzo_82, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
-], "sanzo", "Sanzo Wada, Combination 82")
-loadcolorscheme(:sanzo_83, [
-    RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 83")
-loadcolorscheme(:sanzo_84, [
-    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
-], "sanzo", "Sanzo Wada, Combination 84")
-loadcolorscheme(:sanzo_85, [
-    RGB(0.7803921568627451, 0.2627450980392157, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 85")
-loadcolorscheme(:sanzo_86, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.2, 1.0, 0.49019607843137253)
-], "sanzo", "Sanzo Wada, Combination 86")
-loadcolorscheme(:sanzo_87, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627)
-], "sanzo", "Sanzo Wada, Combination 87")
-loadcolorscheme(:sanzo_88, [
-    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 88")
-loadcolorscheme(:sanzo_89, [
-    RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 89")
-loadcolorscheme(:sanzo_90, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 90")
-loadcolorscheme(:sanzo_91, [
-    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
-        RGB(0.7529411764705882, 0.3215686274509804, 0.0)
-], "sanzo", "Sanzo Wada, Combination 91")
-loadcolorscheme(:sanzo_92, [
-    RGB(1.0, 0.45098039215686275, 0.6),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
-], "sanzo", "Sanzo Wada, Combination 92")
-loadcolorscheme(:sanzo_93, [
-    RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
-], "sanzo", "Sanzo Wada, Combination 93")
-loadcolorscheme(:sanzo_94, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
-], "sanzo", "Sanzo Wada, Combination 94")
-loadcolorscheme(:sanzo_95, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
-], "sanzo", "Sanzo Wada, Combination 95")
-loadcolorscheme(:sanzo_96, [
-    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.44313725490196076, 0.5254901960784314, 0.0)
-], "sanzo", "Sanzo Wada, Combination 96")
-loadcolorscheme(:sanzo_97, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078)
-], "sanzo", "Sanzo Wada, Combination 97")
-loadcolorscheme(:sanzo_98, [
-    RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 98")
-loadcolorscheme(:sanzo_99, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
-], "sanzo", "Sanzo Wada, Combination 99")
-loadcolorscheme(:sanzo_100, [
-    RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
-        RGB(0.43137254901960786, 0.4, 0.8313725490196079)
-], "sanzo", "Sanzo Wada, Combination 100")
-loadcolorscheme(:sanzo_101, [
-    RGB(0.0, 0.1411764705882353, 0.8)
-], "sanzo", "Sanzo Wada, Combination 101")
-loadcolorscheme(:sanzo_102, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.7529411764705882, 0.3215686274509804, 0.0)
-], "sanzo", "Sanzo Wada, Combination 102")
-loadcolorscheme(:sanzo_103, [
-    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
-], "sanzo", "Sanzo Wada, Combination 103")
-loadcolorscheme(:sanzo_104, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804)
-], "sanzo", "Sanzo Wada, Combination 104")
-loadcolorscheme(:sanzo_105, [
-    RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353)
-], "sanzo", "Sanzo Wada, Combination 105")
-loadcolorscheme(:sanzo_106, [
-    RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
-], "sanzo", "Sanzo Wada, Combination 106")
-loadcolorscheme(:sanzo_107, [
-    RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765)
-], "sanzo", "Sanzo Wada, Combination 107")
-loadcolorscheme(:sanzo_108, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.6392156862745098, 0.12941176470588237, 0.0)
-], "sanzo", "Sanzo Wada, Combination 108")
-loadcolorscheme(:sanzo_109, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117)
-], "sanzo", "Sanzo Wada, Combination 109")
-loadcolorscheme(:sanzo_110, [
-    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392)
-], "sanzo", "Sanzo Wada, Combination 110")
-loadcolorscheme(:sanzo_111, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.6509803921568628, 1.0, 0.2784313725490196)
-], "sanzo", "Sanzo Wada, Combination 111")
-loadcolorscheme(:sanzo_112, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 112")
-loadcolorscheme(:sanzo_113, [
-    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392)
-], "sanzo", "Sanzo Wada, Combination 113")
-loadcolorscheme(:sanzo_114, [
-    RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 114")
-loadcolorscheme(:sanzo_115, [
-    RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-        RGB(1.0, 0.2, 0.09803921568627451)
-], "sanzo", "Sanzo Wada, Combination 115")
-loadcolorscheme(:sanzo_116, [
-    RGB(0.2784313725490196, 0.2, 1.0)
-], "sanzo", "Sanzo Wada, Combination 116")
-loadcolorscheme(:sanzo_117, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 117")
-loadcolorscheme(:sanzo_118, [
-    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392)
-], "sanzo", "Sanzo Wada, Combination 118")
-loadcolorscheme(:sanzo_119, [
-    RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
-], "sanzo", "Sanzo Wada, Combination 119")
-loadcolorscheme(:sanzo_120, [
-    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294)
-], "sanzo", "Sanzo Wada, Combination 120")
-loadcolorscheme(:sanzo_121, [
-    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 23")
+loadcolorscheme(:sanzo_024, [
+        RGB(0.3137254901960784, 0.23921568627450981, 0.0),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 24")
+loadcolorscheme(:sanzo_025, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 25")
+loadcolorscheme(:sanzo_026, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 26")
+loadcolorscheme(:sanzo_027, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 27")
+loadcolorscheme(:sanzo_028, [
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzo", "Sanzo Wada, Combination 28")
+loadcolorscheme(:sanzo_029, [
+        RGB(0.4588235294117647, 0.5725490196078431, 0.2627450980392157),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 29")
+loadcolorscheme(:sanzo_030, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
+    ], "sanzo", "Sanzo Wada, Combination 30")
+loadcolorscheme(:sanzo_031, [
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 31")
+loadcolorscheme(:sanzo_032, [
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
-], "sanzo", "Sanzo Wada, Combination 121")
-loadcolorscheme(:sanzo_122, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
-], "sanzo", "Sanzo Wada, Combination 122")
-loadcolorscheme(:sanzo_123, [
-    RGB(1.0, 0.45098039215686275, 0.6),
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
-], "sanzo", "Sanzo Wada, Combination 123")
-loadcolorscheme(:sanzo_124, [
-    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 32")
+loadcolorscheme(:sanzo_033, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 33")
+loadcolorscheme(:sanzo_034, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 34")
+loadcolorscheme(:sanzo_035, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    ], "sanzo", "Sanzo Wada, Combination 35")
+loadcolorscheme(:sanzo_036, [
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 36")
+loadcolorscheme(:sanzo_037, [
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 37")
+loadcolorscheme(:sanzo_038, [
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 38")
+loadcolorscheme(:sanzo_039, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzo", "Sanzo Wada, Combination 39")
+loadcolorscheme(:sanzo_040, [
+        RGB(0.7803921568627451, 0.2627450980392157, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 40")
+loadcolorscheme(:sanzo_041, [
+        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 41")
+loadcolorscheme(:sanzo_042, [
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.6, 0.7019607843137254, 0.2)
-], "sanzo", "Sanzo Wada, Combination 124")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 42")
+loadcolorscheme(:sanzo_043, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 43")
+loadcolorscheme(:sanzo_044, [
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 44")
+loadcolorscheme(:sanzo_045, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    ], "sanzo", "Sanzo Wada, Combination 45")
+loadcolorscheme(:sanzo_046, [
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 46")
+loadcolorscheme(:sanzo_047, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 47")
+loadcolorscheme(:sanzo_048, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzo", "Sanzo Wada, Combination 48")
+loadcolorscheme(:sanzo_049, [
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 49")
+loadcolorscheme(:sanzo_050, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 50")
+loadcolorscheme(:sanzo_051, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 51")
+loadcolorscheme(:sanzo_052, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 52")
+loadcolorscheme(:sanzo_053, [
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 53")
+loadcolorscheme(:sanzo_054, [
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 54")
+loadcolorscheme(:sanzo_055, [
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(1.0, 1.0, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 55")
+loadcolorscheme(:sanzo_056, [
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 56")
+loadcolorscheme(:sanzo_057, [
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 57")
+loadcolorscheme(:sanzo_058, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzo", "Sanzo Wada, Combination 58")
+loadcolorscheme(:sanzo_059, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+    ], "sanzo", "Sanzo Wada, Combination 59")
+loadcolorscheme(:sanzo_060, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 60")
+loadcolorscheme(:sanzo_061, [
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzo", "Sanzo Wada, Combination 61")
+loadcolorscheme(:sanzo_062, [
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 62")
+loadcolorscheme(:sanzo_063, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 63")
+loadcolorscheme(:sanzo_064, [
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
+    ], "sanzo", "Sanzo Wada, Combination 64")
+loadcolorscheme(:sanzo_065, [
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 65")
+loadcolorscheme(:sanzo_066, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 66")
+loadcolorscheme(:sanzo_067, [
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 67")
+loadcolorscheme(:sanzo_068, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(1.0, 1.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 68")
+loadcolorscheme(:sanzo_069, [
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 69")
+loadcolorscheme(:sanzo_070, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzo", "Sanzo Wada, Combination 70")
+loadcolorscheme(:sanzo_071, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+    ], "sanzo", "Sanzo Wada, Combination 71")
+loadcolorscheme(:sanzo_072, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzo", "Sanzo Wada, Combination 72")
+loadcolorscheme(:sanzo_073, [
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 73")
+loadcolorscheme(:sanzo_074, [
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 74")
+loadcolorscheme(:sanzo_075, [
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 75")
+loadcolorscheme(:sanzo_076, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 76")
+loadcolorscheme(:sanzo_077, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    ], "sanzo", "Sanzo Wada, Combination 77")
+loadcolorscheme(:sanzo_078, [
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzo", "Sanzo Wada, Combination 78")
+loadcolorscheme(:sanzo_079, [
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 79")
+loadcolorscheme(:sanzo_080, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 80")
+loadcolorscheme(:sanzo_081, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 81")
+loadcolorscheme(:sanzo_082, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 82")
+loadcolorscheme(:sanzo_083, [
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 83")
+loadcolorscheme(:sanzo_084, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzo", "Sanzo Wada, Combination 84")
+loadcolorscheme(:sanzo_085, [
+        RGB(0.7803921568627451, 0.2627450980392157, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 85")
+loadcolorscheme(:sanzo_086, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzo", "Sanzo Wada, Combination 86")
+loadcolorscheme(:sanzo_087, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    ], "sanzo", "Sanzo Wada, Combination 87")
+loadcolorscheme(:sanzo_088, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 88")
+loadcolorscheme(:sanzo_089, [
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 89")
+loadcolorscheme(:sanzo_090, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 90")
+loadcolorscheme(:sanzo_091, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 91")
+loadcolorscheme(:sanzo_092, [
+        RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzo", "Sanzo Wada, Combination 92")
+loadcolorscheme(:sanzo_093, [
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 93")
+loadcolorscheme(:sanzo_094, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 94")
+loadcolorscheme(:sanzo_095, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzo", "Sanzo Wada, Combination 95")
+loadcolorscheme(:sanzo_096, [
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 96")
+loadcolorscheme(:sanzo_097, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 97")
+loadcolorscheme(:sanzo_098, [
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 98")
+loadcolorscheme(:sanzo_099, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 99")
+loadcolorscheme(:sanzo_100, [
+        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
+        RGB(0.43137254901960786, 0.4, 0.8313725490196079),
+    ], "sanzo", "Sanzo Wada, Combination 100")
+loadcolorscheme(:sanzo_101, [
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 101")
+loadcolorscheme(:sanzo_102, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 102")
+loadcolorscheme(:sanzo_103, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 103")
+loadcolorscheme(:sanzo_104, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 104")
+loadcolorscheme(:sanzo_105, [
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
+    ], "sanzo", "Sanzo Wada, Combination 105")
+loadcolorscheme(:sanzo_106, [
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzo", "Sanzo Wada, Combination 106")
+loadcolorscheme(:sanzo_107, [
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
+    ], "sanzo", "Sanzo Wada, Combination 107")
+loadcolorscheme(:sanzo_108, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 108")
+loadcolorscheme(:sanzo_109, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
+    ], "sanzo", "Sanzo Wada, Combination 109")
+loadcolorscheme(:sanzo_110, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+    ], "sanzo", "Sanzo Wada, Combination 110")
+loadcolorscheme(:sanzo_111, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 111")
+loadcolorscheme(:sanzo_112, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 112")
+loadcolorscheme(:sanzo_113, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+    ], "sanzo", "Sanzo Wada, Combination 113")
+loadcolorscheme(:sanzo_114, [
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 114")
+loadcolorscheme(:sanzo_115, [
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(1.0, 0.2, 0.09803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 115")
+loadcolorscheme(:sanzo_116, [
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 116")
+loadcolorscheme(:sanzo_117, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 117")
+loadcolorscheme(:sanzo_118, [
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+    ], "sanzo", "Sanzo Wada, Combination 118")
+loadcolorscheme(:sanzo_119, [
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 119")
+loadcolorscheme(:sanzo_120, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+    ], "sanzo", "Sanzo Wada, Combination 120")
+loadcolorscheme(:sanzo_121, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzo", "Sanzo Wada, Combination 121")
+loadcolorscheme(:sanzo_122, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzo", "Sanzo Wada, Combination 122")
+loadcolorscheme(:sanzo_123, [
+        RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzo", "Sanzo Wada, Combination 123")
+loadcolorscheme(:sanzo_124, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.6, 0.7019607843137254, 0.2),
+    ], "sanzo", "Sanzo Wada, Combination 124")
 loadcolorscheme(:sanzo_125, [
-    RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 125")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 125")
 loadcolorscheme(:sanzo_126, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.0, 0.1411764705882353, 0.8)
-], "sanzo", "Sanzo Wada, Combination 126")
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 126")
 loadcolorscheme(:sanzo_127, [
-    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
-        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177)
-], "sanzo", "Sanzo Wada, Combination 127")
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
+    ], "sanzo", "Sanzo Wada, Combination 127")
 loadcolorscheme(:sanzo_128, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 128")
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 128")
 loadcolorscheme(:sanzo_129, [
-    RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 129")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 129")
 loadcolorscheme(:sanzo_130, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 130")
-loadcolorscheme(:sanzo_131, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.0, 0.8117647058823529, 0.5686274509803921)
-], "sanzo", "Sanzo Wada, Combination 131")
-loadcolorscheme(:sanzo_132, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744)
-], "sanzo", "Sanzo Wada, Combination 132")
-loadcolorscheme(:sanzo_133, [
-    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
-        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-        RGB(0.2, 1.0, 0.49019607843137253)
-], "sanzo", "Sanzo Wada, Combination 133")
-loadcolorscheme(:sanzo_134, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 134")
-loadcolorscheme(:sanzo_135, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 135")
-loadcolorscheme(:sanzo_136, [
-    RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
-        RGB(0.09803921568627451, 0.8, 0.2),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 136")
-loadcolorscheme(:sanzo_137, [
-    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786)
-], "sanzo", "Sanzo Wada, Combination 137")
-loadcolorscheme(:sanzo_138, [
-    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
-], "sanzo", "Sanzo Wada, Combination 138")
-loadcolorscheme(:sanzo_139, [
-    RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 139")
-loadcolorscheme(:sanzo_140, [
-    RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 140")
-loadcolorscheme(:sanzo_141, [
-    RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
-], "sanzo", "Sanzo Wada, Combination 141")
-loadcolorscheme(:sanzo_142, [
-    RGB(0.6196078431372549, 0.09803921568627451, 0.30196078431372547),
-        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 142")
-loadcolorscheme(:sanzo_143, [
-    RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 143")
-loadcolorscheme(:sanzo_144, [
-    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
-        RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 144")
-loadcolorscheme(:sanzo_145, [
-    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
-], "sanzo", "Sanzo Wada, Combination 145")
-loadcolorscheme(:sanzo_146, [
-    RGB(0.7137254901960784, 0.5176470588235295, 0.0),
-        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
-        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 146")
-loadcolorscheme(:sanzo_147, [
-    RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 147")
-loadcolorscheme(:sanzo_148, [
-    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
-], "sanzo", "Sanzo Wada, Combination 148")
-loadcolorscheme(:sanzo_149, [
-    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(1.0, 0.3215686274509804, 0.0),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
-], "sanzo", "Sanzo Wada, Combination 149")
-loadcolorscheme(:sanzo_150, [
-    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 150")
-loadcolorscheme(:sanzo_151, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(1.0, 0.5490196078431373, 0.0)
-], "sanzo", "Sanzo Wada, Combination 151")
-loadcolorscheme(:sanzo_152, [
-    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
-], "sanzo", "Sanzo Wada, Combination 152")
-loadcolorscheme(:sanzo_153, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(1.0, 0.6705882352941176, 0.0)
-], "sanzo", "Sanzo Wada, Combination 153")
-loadcolorscheme(:sanzo_154, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(1.0, 1.0, 0.0),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 154")
-loadcolorscheme(:sanzo_155, [
-    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
-], "sanzo", "Sanzo Wada, Combination 155")
-loadcolorscheme(:sanzo_156, [
-    RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 156")
-loadcolorscheme(:sanzo_157, [
-    RGB(0.43529411764705883, 0.0, 0.2627450980392157),
-        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 157")
-loadcolorscheme(:sanzo_158, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.47843137254901963, 1.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 158")
-loadcolorscheme(:sanzo_159, [
-    RGB(0.7137254901960784, 0.5176470588235295, 0.0),
-        RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
-], "sanzo", "Sanzo Wada, Combination 159")
-loadcolorscheme(:sanzo_160, [
-    RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667)
-], "sanzo", "Sanzo Wada, Combination 160")
-loadcolorscheme(:sanzo_161, [
-    RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
-], "sanzo", "Sanzo Wada, Combination 161")
-loadcolorscheme(:sanzo_162, [
-    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
-        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803)
-], "sanzo", "Sanzo Wada, Combination 162")
-loadcolorscheme(:sanzo_163, [
-    RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 163")
-loadcolorscheme(:sanzo_164, [
-    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
-        RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 164")
-loadcolorscheme(:sanzo_165, [
-    RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763)
-], "sanzo", "Sanzo Wada, Combination 165")
-loadcolorscheme(:sanzo_166, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
-], "sanzo", "Sanzo Wada, Combination 166")
-loadcolorscheme(:sanzo_167, [
-    RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
-], "sanzo", "Sanzo Wada, Combination 167")
-loadcolorscheme(:sanzo_168, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647)
-], "sanzo", "Sanzo Wada, Combination 168")
-loadcolorscheme(:sanzo_169, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 169")
-loadcolorscheme(:sanzo_170, [
-    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
-        RGB(1.0, 0.6705882352941176, 0.0),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 170")
-loadcolorscheme(:sanzo_171, [
-    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
-        RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 171")
-loadcolorscheme(:sanzo_172, [
-    RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 172")
-loadcolorscheme(:sanzo_173, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 173")
-loadcolorscheme(:sanzo_174, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
-], "sanzo", "Sanzo Wada, Combination 174")
-loadcolorscheme(:sanzo_175, [
-    RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
-        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
-        RGB(0.2784313725490196, 0.2, 1.0)
-], "sanzo", "Sanzo Wada, Combination 175")
-loadcolorscheme(:sanzo_176, [
-    RGB(1.0, 0.7019607843137254, 0.9411764705882353),
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.5019607843137255, 1.0, 0.8)
-], "sanzo", "Sanzo Wada, Combination 176")
-loadcolorscheme(:sanzo_177, [
-    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
-        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0)
-], "sanzo", "Sanzo Wada, Combination 177")
-loadcolorscheme(:sanzo_178, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 178")
-loadcolorscheme(:sanzo_179, [
-    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
-        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
-        RGB(0.0, 0.1411764705882353, 0.8)
-], "sanzo", "Sanzo Wada, Combination 179")
-loadcolorscheme(:sanzo_180, [
-    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
-        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 180")
-loadcolorscheme(:sanzo_181, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
-], "sanzo", "Sanzo Wada, Combination 181")
-loadcolorscheme(:sanzo_182, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
-], "sanzo", "Sanzo Wada, Combination 182")
-loadcolorscheme(:sanzo_183, [
-    RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
-        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 183")
-loadcolorscheme(:sanzo_184, [
-    RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765)
-], "sanzo", "Sanzo Wada, Combination 184")
-loadcolorscheme(:sanzo_185, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
-        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 185")
-loadcolorscheme(:sanzo_186, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 186")
-loadcolorscheme(:sanzo_187, [
-    RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 187")
-loadcolorscheme(:sanzo_188, [
-    RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 188")
-loadcolorscheme(:sanzo_189, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
-], "sanzo", "Sanzo Wada, Combination 189")
-loadcolorscheme(:sanzo_190, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    ], "sanzo", "Sanzo Wada, Combination 130")
+loadcolorscheme(:sanzo_131, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 190")
-loadcolorscheme(:sanzo_191, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
-        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 191")
-loadcolorscheme(:sanzo_192, [
-    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
-        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
-        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824)
-], "sanzo", "Sanzo Wada, Combination 192")
-loadcolorscheme(:sanzo_193, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
-        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156)
-], "sanzo", "Sanzo Wada, Combination 193")
-loadcolorscheme(:sanzo_194, [
-    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
-        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 194")
-loadcolorscheme(:sanzo_195, [
-    RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 195")
-loadcolorscheme(:sanzo_196, [
-    RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.2784313725490196, 0.2, 1.0)
-], "sanzo", "Sanzo Wada, Combination 196")
-loadcolorscheme(:sanzo_197, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
-        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 197")
-loadcolorscheme(:sanzo_198, [
-    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
-        RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 198")
-loadcolorscheme(:sanzo_199, [
-    RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
-        RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
-        RGB(0.0, 0.1411764705882353, 0.8)
-], "sanzo", "Sanzo Wada, Combination 199")
-loadcolorscheme(:sanzo_200, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
-        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353)
-], "sanzo", "Sanzo Wada, Combination 200")
-loadcolorscheme(:sanzo_201, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 201")
-loadcolorscheme(:sanzo_202, [
-    RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 202")
-loadcolorscheme(:sanzo_203, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
-], "sanzo", "Sanzo Wada, Combination 203")
-loadcolorscheme(:sanzo_204, [
-    RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
-], "sanzo", "Sanzo Wada, Combination 204")
-loadcolorscheme(:sanzo_205, [
-    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
-        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 205")
-loadcolorscheme(:sanzo_206, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
-        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313)
-], "sanzo", "Sanzo Wada, Combination 206")
-loadcolorscheme(:sanzo_207, [
-    RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 207")
-loadcolorscheme(:sanzo_208, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 208")
-loadcolorscheme(:sanzo_209, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 209")
-loadcolorscheme(:sanzo_210, [
-    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.0, 0.8117647058823529, 0.5686274509803921),
+    ], "sanzo", "Sanzo Wada, Combination 131")
+loadcolorscheme(:sanzo_132, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+    ], "sanzo", "Sanzo Wada, Combination 132")
+loadcolorscheme(:sanzo_133, [
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzo", "Sanzo Wada, Combination 133")
+loadcolorscheme(:sanzo_134, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 134")
+loadcolorscheme(:sanzo_135, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 135")
+loadcolorscheme(:sanzo_136, [
+        RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
+        RGB(0.09803921568627451, 0.8, 0.2),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 136")
+loadcolorscheme(:sanzo_137, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    ], "sanzo", "Sanzo Wada, Combination 137")
+loadcolorscheme(:sanzo_138, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157)
-], "sanzo", "Sanzo Wada, Combination 210")
-loadcolorscheme(:sanzo_211, [
-    RGB(1.0, 0.45098039215686275, 0.25098039215686274),
-        RGB(0.6, 0.7019607843137254, 0.2),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
-], "sanzo", "Sanzo Wada, Combination 211")
-loadcolorscheme(:sanzo_212, [
-    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
-        RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 212")
-loadcolorscheme(:sanzo_213, [
-    RGB(0.9607843137254902, 0.6, 0.5803921568627451),
-        RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
-], "sanzo", "Sanzo Wada, Combination 213")
-loadcolorscheme(:sanzo_214, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 214")
-loadcolorscheme(:sanzo_215, [
-    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 215")
-loadcolorscheme(:sanzo_216, [
-    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
-        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 216")
-loadcolorscheme(:sanzo_217, [
-    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 217")
-loadcolorscheme(:sanzo_218, [
-    RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824)
-], "sanzo", "Sanzo Wada, Combination 218")
-loadcolorscheme(:sanzo_219, [
-    RGB(0.9803921568627451, 0.16862745098039217, 0.0),
-        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
-], "sanzo", "Sanzo Wada, Combination 219")
-loadcolorscheme(:sanzo_220, [
-    RGB(0.7254901960784313, 0.0, 0.47058823529411764),
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 220")
-loadcolorscheme(:sanzo_221, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzo", "Sanzo Wada, Combination 138")
+loadcolorscheme(:sanzo_139, [
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 221")
-loadcolorscheme(:sanzo_222, [
-    RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.7529411764705882, 0.3215686274509804, 0.0)
-], "sanzo", "Sanzo Wada, Combination 222")
-loadcolorscheme(:sanzo_223, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
-        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 223")
-loadcolorscheme(:sanzo_224, [
-    RGB(1.0, 0.30196078431372547, 0.788235294117647),
-        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
-], "sanzo", "Sanzo Wada, Combination 224")
-loadcolorscheme(:sanzo_225, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902)
-], "sanzo", "Sanzo Wada, Combination 225")
-loadcolorscheme(:sanzo_226, [
-    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
-        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 226")
-loadcolorscheme(:sanzo_227, [
-    RGB(1.0, 0.7019607843137254, 0.9411764705882353),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
-], "sanzo", "Sanzo Wada, Combination 227")
-loadcolorscheme(:sanzo_228, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 228")
-loadcolorscheme(:sanzo_229, [
-    RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 229")
-loadcolorscheme(:sanzo_230, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 139")
+loadcolorscheme(:sanzo_140, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 140")
+loadcolorscheme(:sanzo_141, [
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 141")
+loadcolorscheme(:sanzo_142, [
+        RGB(0.6196078431372549, 0.09803921568627451, 0.30196078431372547),
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 142")
+loadcolorscheme(:sanzo_143, [
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 143")
+loadcolorscheme(:sanzo_144, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 144")
+loadcolorscheme(:sanzo_145, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzo", "Sanzo Wada, Combination 145")
+loadcolorscheme(:sanzo_146, [
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 146")
+loadcolorscheme(:sanzo_147, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 230")
-loadcolorscheme(:sanzo_231, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
-        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 231")
-loadcolorscheme(:sanzo_232, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
-        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
-        RGB(0.0, 0.03137254901960784, 0.19215686274509805)
-], "sanzo", "Sanzo Wada, Combination 232")
-loadcolorscheme(:sanzo_233, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
-        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 233")
-loadcolorscheme(:sanzo_234, [
-    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
-        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824)
-], "sanzo", "Sanzo Wada, Combination 234")
-loadcolorscheme(:sanzo_235, [
-    RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+    ], "sanzo", "Sanzo Wada, Combination 147")
+loadcolorscheme(:sanzo_148, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 148")
+loadcolorscheme(:sanzo_149, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzo", "Sanzo Wada, Combination 149")
+loadcolorscheme(:sanzo_150, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 150")
+loadcolorscheme(:sanzo_151, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
-], "sanzo", "Sanzo Wada, Combination 235")
-loadcolorscheme(:sanzo_236, [
-    RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 151")
+loadcolorscheme(:sanzo_152, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 152")
+loadcolorscheme(:sanzo_153, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.6705882352941176, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 153")
+loadcolorscheme(:sanzo_154, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 154")
+loadcolorscheme(:sanzo_155, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzo", "Sanzo Wada, Combination 155")
+loadcolorscheme(:sanzo_156, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 156")
+loadcolorscheme(:sanzo_157, [
+        RGB(0.43529411764705883, 0.0, 0.2627450980392157),
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 157")
+loadcolorscheme(:sanzo_158, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 158")
+loadcolorscheme(:sanzo_159, [
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.5019607843137255, 1.0, 0.8),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 159")
+loadcolorscheme(:sanzo_160, [
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+    ], "sanzo", "Sanzo Wada, Combination 160")
+loadcolorscheme(:sanzo_161, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzo", "Sanzo Wada, Combination 161")
+loadcolorscheme(:sanzo_162, [
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+    ], "sanzo", "Sanzo Wada, Combination 162")
+loadcolorscheme(:sanzo_163, [
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 163")
+loadcolorscheme(:sanzo_164, [
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 164")
+loadcolorscheme(:sanzo_165, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+    ], "sanzo", "Sanzo Wada, Combination 165")
+loadcolorscheme(:sanzo_166, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzo", "Sanzo Wada, Combination 166")
+loadcolorscheme(:sanzo_167, [
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzo", "Sanzo Wada, Combination 167")
+loadcolorscheme(:sanzo_168, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 168")
+loadcolorscheme(:sanzo_169, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 169")
+loadcolorscheme(:sanzo_170, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 170")
+loadcolorscheme(:sanzo_171, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 171")
+loadcolorscheme(:sanzo_172, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 172")
+loadcolorscheme(:sanzo_173, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 173")
+loadcolorscheme(:sanzo_174, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzo", "Sanzo Wada, Combination 174")
+loadcolorscheme(:sanzo_175, [
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 175")
+loadcolorscheme(:sanzo_176, [
+        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 176")
+loadcolorscheme(:sanzo_177, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 177")
+loadcolorscheme(:sanzo_178, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 178")
+loadcolorscheme(:sanzo_179, [
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
         RGB(0.0, 0.1411764705882353, 0.8),
-        RGB(0.4588235294117647, 0.25882352941176473, 0.3764705882352941)
-], "sanzo", "Sanzo Wada, Combination 236")
+    ], "sanzo", "Sanzo Wada, Combination 179")
+loadcolorscheme(:sanzo_180, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 180")
+loadcolorscheme(:sanzo_181, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzo", "Sanzo Wada, Combination 181")
+loadcolorscheme(:sanzo_182, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzo", "Sanzo Wada, Combination 182")
+loadcolorscheme(:sanzo_183, [
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 183")
+loadcolorscheme(:sanzo_184, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
+    ], "sanzo", "Sanzo Wada, Combination 184")
+loadcolorscheme(:sanzo_185, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 185")
+loadcolorscheme(:sanzo_186, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 186")
+loadcolorscheme(:sanzo_187, [
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 187")
+loadcolorscheme(:sanzo_188, [
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 188")
+loadcolorscheme(:sanzo_189, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzo", "Sanzo Wada, Combination 189")
+loadcolorscheme(:sanzo_190, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 190")
+loadcolorscheme(:sanzo_191, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 191")
+loadcolorscheme(:sanzo_192, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
+    ], "sanzo", "Sanzo Wada, Combination 192")
+loadcolorscheme(:sanzo_193, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
+    ], "sanzo", "Sanzo Wada, Combination 193")
+loadcolorscheme(:sanzo_194, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 194")
+loadcolorscheme(:sanzo_195, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 195")
+loadcolorscheme(:sanzo_196, [
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 196")
+loadcolorscheme(:sanzo_197, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 197")
+loadcolorscheme(:sanzo_198, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 198")
+loadcolorscheme(:sanzo_199, [
+        RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
+        RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 199")
+loadcolorscheme(:sanzo_200, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
+    ], "sanzo", "Sanzo Wada, Combination 200")
+loadcolorscheme(:sanzo_201, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 201")
+loadcolorscheme(:sanzo_202, [
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 202")
+loadcolorscheme(:sanzo_203, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzo", "Sanzo Wada, Combination 203")
+loadcolorscheme(:sanzo_204, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 204")
+loadcolorscheme(:sanzo_205, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 205")
+loadcolorscheme(:sanzo_206, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+    ], "sanzo", "Sanzo Wada, Combination 206")
+loadcolorscheme(:sanzo_207, [
+        RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 207")
+loadcolorscheme(:sanzo_208, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 208")
+loadcolorscheme(:sanzo_209, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 209")
+loadcolorscheme(:sanzo_210, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzo", "Sanzo Wada, Combination 210")
+loadcolorscheme(:sanzo_211, [
+        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+        RGB(0.6, 0.7019607843137254, 0.2),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzo", "Sanzo Wada, Combination 211")
+loadcolorscheme(:sanzo_212, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 212")
+loadcolorscheme(:sanzo_213, [
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzo", "Sanzo Wada, Combination 213")
+loadcolorscheme(:sanzo_214, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 214")
+loadcolorscheme(:sanzo_215, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 215")
+loadcolorscheme(:sanzo_216, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 216")
+loadcolorscheme(:sanzo_217, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 217")
+loadcolorscheme(:sanzo_218, [
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
+    ], "sanzo", "Sanzo Wada, Combination 218")
+loadcolorscheme(:sanzo_219, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 219")
+loadcolorscheme(:sanzo_220, [
+        RGB(0.7254901960784313, 0.0, 0.47058823529411764),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 220")
+loadcolorscheme(:sanzo_221, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 221")
+loadcolorscheme(:sanzo_222, [
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 222")
+loadcolorscheme(:sanzo_223, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 223")
+loadcolorscheme(:sanzo_224, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzo", "Sanzo Wada, Combination 224")
+loadcolorscheme(:sanzo_225, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 225")
+loadcolorscheme(:sanzo_226, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 226")
+loadcolorscheme(:sanzo_227, [
+        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 227")
+loadcolorscheme(:sanzo_228, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 228")
+loadcolorscheme(:sanzo_229, [
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 229")
+loadcolorscheme(:sanzo_230, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 230")
+loadcolorscheme(:sanzo_231, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 231")
+loadcolorscheme(:sanzo_232, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzo", "Sanzo Wada, Combination 232")
+loadcolorscheme(:sanzo_233, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 233")
+loadcolorscheme(:sanzo_234, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzo", "Sanzo Wada, Combination 234")
+loadcolorscheme(:sanzo_235, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 235")
+loadcolorscheme(:sanzo_236, [
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.0, 0.1411764705882353, 0.8),
+        RGB(0.4588235294117647, 0.25882352941176473, 0.3764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 236")
 loadcolorscheme(:sanzo_237, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
         RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 237")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 237")
 loadcolorscheme(:sanzo_238, [
-    RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 238")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 238")
 loadcolorscheme(:sanzo_239, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
-        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 239")
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 239")
 loadcolorscheme(:sanzo_240, [
-    RGB(1.0, 0.47058823529411764, 0.5490196078431373),
+        RGB(1.0, 0.47058823529411764, 0.5490196078431373),
         RGB(1.0, 1.0, 0.0),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
-], "sanzo", "Sanzo Wada, Combination 240")
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 240")
 loadcolorscheme(:sanzo_241, [
-    RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667)
-], "sanzo", "Sanzo Wada, Combination 241")
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+    ], "sanzo", "Sanzo Wada, Combination 241")
 loadcolorscheme(:sanzo_242, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 242")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 242")
 loadcolorscheme(:sanzo_243, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 243")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 243")
 loadcolorscheme(:sanzo_244, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7803921568627451, 0.2627450980392157, 0.0),
         RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 244")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 244")
 loadcolorscheme(:sanzo_245, [
-    RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
         RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 245")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 245")
 loadcolorscheme(:sanzo_246, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
-        RGB(1.0, 0.7490196078431373, 0.43137254901960786)
-], "sanzo", "Sanzo Wada, Combination 246")
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    ], "sanzo", "Sanzo Wada, Combination 246")
 loadcolorscheme(:sanzo_247, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.0, 0.1411764705882353, 0.8)
-], "sanzo", "Sanzo Wada, Combination 247")
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 247")
 loadcolorscheme(:sanzo_248, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7137254901960784, 0.5176470588235295, 0.0),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
-        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902)
-], "sanzo", "Sanzo Wada, Combination 248")
+        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 248")
 loadcolorscheme(:sanzo_249, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
-        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667)
-], "sanzo", "Sanzo Wada, Combination 249")
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+    ], "sanzo", "Sanzo Wada, Combination 249")
 loadcolorscheme(:sanzo_250, [
-    RGB(0.7686274509803922, 0.7490196078431373, 0.2),
+        RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 250")
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 250")
 loadcolorscheme(:sanzo_251, [
-    RGB(0.6313725490196078, 0.0, 0.27058823529411763),
+        RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 251")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 251")
 loadcolorscheme(:sanzo_252, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7294117647058823, 0.6509803921568628, 0.0),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 252")
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 252")
 loadcolorscheme(:sanzo_253, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 253")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 253")
 loadcolorscheme(:sanzo_254, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.8, 0.5215686274509804, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 254")
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 254")
 loadcolorscheme(:sanzo_255, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 255")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 255")
 loadcolorscheme(:sanzo_256, [
-    RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.09803921568627451, 0.8, 0.2),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 256")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 256")
 loadcolorscheme(:sanzo_257, [
-    RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(0.9490196078431372, 0.0, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 257")
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 257")
 loadcolorscheme(:sanzo_258, [
-    RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 258")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 258")
 loadcolorscheme(:sanzo_259, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 259")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 259")
 loadcolorscheme(:sanzo_260, [
-    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
-        RGB(0.2, 1.0, 0.49019607843137253)
-], "sanzo", "Sanzo Wada, Combination 260")
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzo", "Sanzo Wada, Combination 260")
 loadcolorscheme(:sanzo_261, [
-    RGB(0.6313725490196078, 0.0, 0.27058823529411763),
+        RGB(0.6313725490196078, 0.0, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.5019607843137255, 1.0, 0.8),
-        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549)
-], "sanzo", "Sanzo Wada, Combination 261")
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 261")
 loadcolorscheme(:sanzo_262, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
         RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 262")
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 262")
 loadcolorscheme(:sanzo_263, [
-    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 263")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 263")
 loadcolorscheme(:sanzo_264, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(0.9098039215686274, 0.09803921568627451, 0.0),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
-        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196)
-], "sanzo", "Sanzo Wada, Combination 264")
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzo", "Sanzo Wada, Combination 264")
 loadcolorscheme(:sanzo_265, [
-    RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.6, 0.7019607843137254, 0.2),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
-], "sanzo", "Sanzo Wada, Combination 265")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzo", "Sanzo Wada, Combination 265")
 loadcolorscheme(:sanzo_266, [
-    RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
-], "sanzo", "Sanzo Wada, Combination 266")
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzo", "Sanzo Wada, Combination 266")
 loadcolorscheme(:sanzo_267, [
-    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 267")
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 267")
 loadcolorscheme(:sanzo_268, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 268")
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 268")
 loadcolorscheme(:sanzo_269, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 269")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 269")
 loadcolorscheme(:sanzo_270, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 270")
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 270")
 loadcolorscheme(:sanzo_271, [
-    RGB(0.7254901960784313, 0.0, 0.47058823529411764),
+        RGB(0.7254901960784313, 0.0, 0.47058823529411764),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
         RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
-], "sanzo", "Sanzo Wada, Combination 271")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzo", "Sanzo Wada, Combination 271")
 loadcolorscheme(:sanzo_272, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(1.0, 0.3215686274509804, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 272")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 272")
 loadcolorscheme(:sanzo_273, [
-    RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
         RGB(0.43529411764705883, 0.0, 0.2627450980392157),
         RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 273")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 273")
 loadcolorscheme(:sanzo_274, [
-    RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
-        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 274")
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 274")
 loadcolorscheme(:sanzo_275, [
-    RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
-], "sanzo", "Sanzo Wada, Combination 275")
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzo", "Sanzo Wada, Combination 275")
 loadcolorscheme(:sanzo_276, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 276")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 276")
 loadcolorscheme(:sanzo_277, [
-    RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
         RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
-], "sanzo", "Sanzo Wada, Combination 277")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzo", "Sanzo Wada, Combination 277")
 loadcolorscheme(:sanzo_278, [
-    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
-], "sanzo", "Sanzo Wada, Combination 278")
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 278")
 loadcolorscheme(:sanzo_279, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804)
-], "sanzo", "Sanzo Wada, Combination 279")
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 279")
 loadcolorscheme(:sanzo_280, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
-        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707)
-], "sanzo", "Sanzo Wada, Combination 280")
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzo", "Sanzo Wada, Combination 280")
 loadcolorscheme(:sanzo_281, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 281")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 281")
 loadcolorscheme(:sanzo_282, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.7607843137254902, 0.592156862745098, 0.35294117647058826),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803)
-], "sanzo", "Sanzo Wada, Combination 282")
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+    ], "sanzo", "Sanzo Wada, Combination 282")
 loadcolorscheme(:sanzo_283, [
-    RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
+        RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
         RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
         RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
-        RGB(0.4196078431372549, 1.0, 0.7019607843137254)
-], "sanzo", "Sanzo Wada, Combination 283")
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzo", "Sanzo Wada, Combination 283")
 loadcolorscheme(:sanzo_284, [
-    RGB(0.9294117647058824, 0.23921568627450981, 0.4),
+        RGB(0.9294117647058824, 0.23921568627450981, 0.4),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(0.2, 1.0, 0.49019607843137253),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
-], "sanzo", "Sanzo Wada, Combination 284")
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 284")
 loadcolorscheme(:sanzo_285, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.2, 0.09803921568627451),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 285")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 285")
 loadcolorscheme(:sanzo_286, [
-    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.8117647058823529, 0.5686274509803921),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 286")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 286")
 loadcolorscheme(:sanzo_287, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7686274509803922, 0.7490196078431373, 0.2),
         RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
-        RGB(0.5019607843137255, 1.0, 0.8)
-], "sanzo", "Sanzo Wada, Combination 287")
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 287")
 loadcolorscheme(:sanzo_288, [
-    RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.3137254901960784, 0.23921568627450981, 0.0),
         RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 288")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 288")
 loadcolorscheme(:sanzo_289, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
-], "sanzo", "Sanzo Wada, Combination 289")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzo", "Sanzo Wada, Combination 289")
 loadcolorscheme(:sanzo_290, [
-    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 290")
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 290")
 loadcolorscheme(:sanzo_291, [
-    RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.5019607843137255, 1.0, 0.8)
-], "sanzo", "Sanzo Wada, Combination 291")
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 291")
 loadcolorscheme(:sanzo_292, [
-    RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
-        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412)
-], "sanzo", "Sanzo Wada, Combination 292")
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+    ], "sanzo", "Sanzo Wada, Combination 292")
 loadcolorscheme(:sanzo_293, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
-        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763)
-], "sanzo", "Sanzo Wada, Combination 293")
+        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
+    ], "sanzo", "Sanzo Wada, Combination 293")
 loadcolorscheme(:sanzo_294, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 294")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 294")
 loadcolorscheme(:sanzo_295, [
-    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(1.0, 1.0, 0.0),
         RGB(0.050980392156862744, 0.4588235294117647, 1.0),
-        RGB(0.023529411764705882, 0.0, 0.30980392156862746)
-], "sanzo", "Sanzo Wada, Combination 295")
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzo", "Sanzo Wada, Combination 295")
 loadcolorscheme(:sanzo_296, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 296")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 296")
 loadcolorscheme(:sanzo_297, [
-    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 297")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 297")
 loadcolorscheme(:sanzo_298, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(1.0, 0.2, 0.09803921568627451)
-], "sanzo", "Sanzo Wada, Combination 298")
+        RGB(1.0, 0.2, 0.09803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 298")
 loadcolorscheme(:sanzo_299, [
-    RGB(0.8, 0.10196078431372549, 0.592156862745098),
+        RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.9607843137254902, 0.6, 0.5803921568627451),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 299")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 299")
 loadcolorscheme(:sanzo_300, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7098039215686275, 1.0, 0.7607843137254902),
-        RGB(0.5019607843137255, 1.0, 0.8)
-], "sanzo", "Sanzo Wada, Combination 300")
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 300")
 loadcolorscheme(:sanzo_301, [
-    RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372)
-], "sanzo", "Sanzo Wada, Combination 301")
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzo", "Sanzo Wada, Combination 301")
 loadcolorscheme(:sanzo_302, [
-    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 302")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 302")
 loadcolorscheme(:sanzo_303, [
-    RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 303")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 303")
 loadcolorscheme(:sanzo_304, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
-        RGB(0.0, 0.8509803921568627, 0.45098039215686275)
-], "sanzo", "Sanzo Wada, Combination 304")
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzo", "Sanzo Wada, Combination 304")
 loadcolorscheme(:sanzo_305, [
-    RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(1.0, 0.9019607843137255, 0.0),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 305")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 305")
 loadcolorscheme(:sanzo_306, [
-    RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.0, 0.8509803921568627, 0.45098039215686275),
         RGB(0.09803921568627451, 0.8, 0.2),
-        RGB(0.7490196078431373, 1.0, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 306")
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 306")
 loadcolorscheme(:sanzo_307, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(0.7215686274509804, 0.7215686274509804, 1.0),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
-], "sanzo", "Sanzo Wada, Combination 307")
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzo", "Sanzo Wada, Combination 307")
 loadcolorscheme(:sanzo_308, [
-    RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
         RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
-        RGB(0.5803921568627451, 1.0, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 308")
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 308")
 loadcolorscheme(:sanzo_309, [
-    RGB(1.0, 0.45098039215686275, 0.25098039215686274),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 309")
+        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 309")
 loadcolorscheme(:sanzo_310, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
-        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 310")
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 310")
 loadcolorscheme(:sanzo_311, [
-    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
-        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725)
-], "sanzo", "Sanzo Wada, Combination 311")
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+    ], "sanzo", "Sanzo Wada, Combination 311")
 loadcolorscheme(:sanzo_312, [
-    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
-        RGB(0.0, 0.3411764705882353, 0.7294117647058823)
-], "sanzo", "Sanzo Wada, Combination 312")
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzo", "Sanzo Wada, Combination 312")
 loadcolorscheme(:sanzo_313, [
-    RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
         RGB(1.0, 1.0, 0.0),
         RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 313")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 313")
 loadcolorscheme(:sanzo_314, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.0, 0.1411764705882353, 0.8),
-        RGB(0.17647058823529413, 0.0, 0.3764705882352941)
-], "sanzo", "Sanzo Wada, Combination 314")
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzo", "Sanzo Wada, Combination 314")
 loadcolorscheme(:sanzo_315, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
-        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804)
-], "sanzo", "Sanzo Wada, Combination 315")
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 315")
 loadcolorscheme(:sanzo_316, [
-    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(0.09803921568627451, 0.8, 0.2),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-        RGB(0.20392156862745098, 0.0, 0.6392156862745098)
-], "sanzo", "Sanzo Wada, Combination 316")
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzo", "Sanzo Wada, Combination 316")
 loadcolorscheme(:sanzo_317, [
-    RGB(1.0, 0.7490196078431373, 0.6),
+        RGB(1.0, 0.7490196078431373, 0.6),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
-        RGB(0.7098039215686275, 1.0, 0.7607843137254902)
-], "sanzo", "Sanzo Wada, Combination 317")
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzo", "Sanzo Wada, Combination 317")
 loadcolorscheme(:sanzo_318, [
-    RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
+        RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
         RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
-], "sanzo", "Sanzo Wada, Combination 318")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzo", "Sanzo Wada, Combination 318")
 loadcolorscheme(:sanzo_319, [
-    RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(1.0, 0.9019607843137255, 0.0),
         RGB(1.0, 0.5490196078431373, 0.0),
-        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 319")
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 319")
 loadcolorscheme(:sanzo_320, [
-    RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.43137254901960786, 0.6627450980392157, 0.0),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
-], "sanzo", "Sanzo Wada, Combination 320")
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 320")
 loadcolorscheme(:sanzo_321, [
-    RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
         RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255)
-], "sanzo", "Sanzo Wada, Combination 321")
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzo", "Sanzo Wada, Combination 321")
 loadcolorscheme(:sanzo_322, [
-    RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(0.9490196078431372, 0.0, 0.0),
         RGB(0.6392156862745098, 0.12941176470588237, 0.0),
-        RGB(0.2784313725490196, 0.2, 1.0)
-], "sanzo", "Sanzo Wada, Combination 322")
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 322")
 loadcolorscheme(:sanzo_323, [
-    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.396078431372549, 0.07450980392156863, 0.0),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 323")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 323")
 loadcolorscheme(:sanzo_324, [
-    RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
         RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.7098039215686275, 0.8196078431372549, 0.8)
-], "sanzo", "Sanzo Wada, Combination 324")
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 324")
 loadcolorscheme(:sanzo_325, [
-    RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
         RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
         RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
-        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039)
-], "sanzo", "Sanzo Wada, Combination 325")
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzo", "Sanzo Wada, Combination 325")
 loadcolorscheme(:sanzo_326, [
-    RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
         RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.47843137254901963, 1.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 326")
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 326")
 loadcolorscheme(:sanzo_327, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.7215686274509804, 0.3686274509803922, 0.0),
         RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
-], "sanzo", "Sanzo Wada, Combination 327")
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 327")
 loadcolorscheme(:sanzo_328, [
-    RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
         RGB(1.0, 0.45098039215686275, 0.25098039215686274),
-        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156)
-], "sanzo", "Sanzo Wada, Combination 328")
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
+    ], "sanzo", "Sanzo Wada, Combination 328")
 loadcolorscheme(:sanzo_329, [
-    RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.7490196078431373, 0.6705882352941176, 0.8),
         RGB(0.20392156862745098, 0.0, 0.34901960784313724),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 329")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 329")
 loadcolorscheme(:sanzo_330, [
-    RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
-        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451)
-], "sanzo", "Sanzo Wada, Combination 330")
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 330")
 loadcolorscheme(:sanzo_331, [
-    RGB(0.8, 0.10196078431372549, 0.592156862745098),
+        RGB(0.8, 0.10196078431372549, 0.592156862745098),
         RGB(0.023529411764705882, 0.0, 0.30980392156862746),
         RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
         RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
-        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549)
-], "sanzo", "Sanzo Wada, Combination 331")
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzo", "Sanzo Wada, Combination 331")
 loadcolorscheme(:sanzo_332, [
-    RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(1.0, 0.45098039215686275, 0.6),
         RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.0, 0.34901960784313724, 0.1803921568627451)
-], "sanzo", "Sanzo Wada, Combination 332")
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzo", "Sanzo Wada, Combination 332")
 loadcolorscheme(:sanzo_333, [
-    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9490196078431372, 1.0, 0.14901960784313725),
         RGB(0.5803921568627451, 1.0, 0.5803921568627451),
-        RGB(0.050980392156862744, 0.4588235294117647, 1.0)
-], "sanzo", "Sanzo Wada, Combination 333")
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 333")
 loadcolorscheme(:sanzo_334, [
-    RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
         RGB(0.44313725490196076, 0.5254901960784314, 0.0),
         RGB(0.6509803921568628, 1.0, 0.2784313725490196),
-        RGB(0.0, 0.5411764705882353, 0.6313725490196078)
-], "sanzo", "Sanzo Wada, Combination 334")
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzo", "Sanzo Wada, Combination 334")
 loadcolorscheme(:sanzo_335, [
-    RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
         RGB(1.0, 0.5490196078431373, 0.0),
         RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
-        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666)
-], "sanzo", "Sanzo Wada, Combination 335")
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzo", "Sanzo Wada, Combination 335")
 loadcolorscheme(:sanzo_336, [
-    RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
         RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(1.0, 0.9607843137254902, 0.6196078431372549),
-        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117)
-], "sanzo", "Sanzo Wada, Combination 336")
+        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
+    ], "sanzo", "Sanzo Wada, Combination 336")
 loadcolorscheme(:sanzo_337, [
-    RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
         RGB(0.8, 0.5215686274509804, 0.8196078431372549),
         RGB(0.3254901960784314, 0.09019607843137255, 0.27058823529411763),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 337")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 337")
 loadcolorscheme(:sanzo_338, [
-    RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(1.0, 0.6705882352941176, 0.0),
         RGB(0.0, 0.34901960784313724, 0.1803921568627451),
-        RGB(0.7490196078431373, 0.6705882352941176, 0.8)
-], "sanzo", "Sanzo Wada, Combination 338")
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzo", "Sanzo Wada, Combination 338")
 loadcolorscheme(:sanzo_339, [
-    RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
         RGB(0.8705882352941177, 0.27058823529411763, 0.0),
         RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
-        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804)
-], "sanzo", "Sanzo Wada, Combination 339")
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzo", "Sanzo Wada, Combination 339")
 loadcolorscheme(:sanzo_340, [
-    RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(1.0, 0.2, 0.09803921568627451),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.7098039215686275, 0.8196078431372549, 0.8),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 340")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 340")
 loadcolorscheme(:sanzo_341, [
-    RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647)
-], "sanzo", "Sanzo Wada, Combination 341")
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzo", "Sanzo Wada, Combination 341")
 loadcolorscheme(:sanzo_342, [
-    RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
         RGB(1.0, 0.7215686274509804, 0.3215686274509804),
         RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
-        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863)
-], "sanzo", "Sanzo Wada, Combination 342")
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+    ], "sanzo", "Sanzo Wada, Combination 342")
 loadcolorscheme(:sanzo_343, [
-    RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
         RGB(0.9215686274509803, 0.8509803921568627, 0.6),
-        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433)
-], "sanzo", "Sanzo Wada, Combination 343")
+        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
+    ], "sanzo", "Sanzo Wada, Combination 343")
 loadcolorscheme(:sanzo_344, [
-    RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
         RGB(0.0, 0.1411764705882353, 0.8),
         RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
-        RGB(0.0, 0.0, 0.0)
-], "sanzo", "Sanzo Wada, Combination 344")
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzo", "Sanzo Wada, Combination 344")
 loadcolorscheme(:sanzo_345, [
-    RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
         RGB(0.7490196078431373, 1.0, 0.9019607843137255),
         RGB(0.4196078431372549, 1.0, 0.7019607843137254),
-        RGB(0.2784313725490196, 0.2, 1.0)
-], "sanzo", "Sanzo Wada, Combination 345")
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzo", "Sanzo Wada, Combination 345")
 loadcolorscheme(:sanzo_346, [
-    RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
         RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
-        RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275)
-], "sanzo", "Sanzo Wada, Combination 346")
+        RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
+    ], "sanzo", "Sanzo Wada, Combination 346")
 loadcolorscheme(:sanzo_347, [
-    RGB(0.6, 0.7019607843137254, 0.2),
+        RGB(0.6, 0.7019607843137254, 0.2),
         RGB(0.2, 1.0, 0.49019607843137253),
         RGB(0.0, 0.3411764705882353, 0.7294117647058823),
-        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803)
-], "sanzo", "Sanzo Wada, Combination 347")
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+    ], "sanzo", "Sanzo Wada, Combination 347")
 loadcolorscheme(:sanzo_348, [
-    RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
         RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
         RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
-        RGB(0.20392156862745098, 0.0, 0.34901960784313724)
-], "sanzo", "Sanzo Wada, Combination 348")
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzo", "Sanzo Wada, Combination 348")

--- a/data/sanzowada.jl
+++ b/data/sanzowada.jl
@@ -1,0 +1,1701 @@
+loadcolorscheme(:sanzowada_1, [
+        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzowada", "Color combination 1 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_2, [
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzowada", "Color combination 2 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_3, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    ], "sanzowada", "Color combination 3 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_4, [
+        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 4 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_5, [
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzowada", "Color combination 5 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_6, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzowada", "Color combination 6 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_7, [
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzowada", "Color combination 7 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_8, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzowada", "Color combination 8 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_9, [
+        RGB(0.23921568627450981, 0.0, 0.4745098039215686),
+        RGB(0.43137254901960786, 0.4, 0.8313725490196079),
+    ], "sanzowada", "Color combination 9 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_10, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
+    ], "sanzowada", "Color combination 10 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_11, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
+    ], "sanzowada", "Color combination 11 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_12, [
+        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzowada", "Color combination 12 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_13, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+    ], "sanzowada", "Color combination 13 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_14, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+    ], "sanzowada", "Color combination 14 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_15, [
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzowada", "Color combination 15 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_16, [
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzowada", "Color combination 16 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_17, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzowada", "Color combination 17 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_18, [
+        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+        RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzowada", "Color combination 18 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_19, [
+        RGB(0.3215686274509804, 0.12549019607843137, 0.0),
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzowada", "Color combination 19 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_20, [
+        RGB(0.5019607843137255, 1.0, 0.8),
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
+    ], "sanzowada", "Color combination 20 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_21, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzowada", "Color combination 21 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_22, [
+        RGB(1.0, 1.0, 0.0),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzowada", "Color combination 22 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_23, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzowada", "Color combination 23 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_24, [
+        RGB(0.3137254901960784, 0.23921568627450981, 0.0),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+    ], "sanzowada", "Color combination 24 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_25, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzowada", "Color combination 25 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_26, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+    ], "sanzowada", "Color combination 26 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_27, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 27 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_28, [
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzowada", "Color combination 28 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_29, [
+        RGB(0.4588235294117647, 0.5725490196078431, 0.2627450980392157),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 29 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_30, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.6235294117647059, 0.7607843137254902, 0.6980392156862745),
+    ], "sanzowada", "Color combination 30 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_31, [
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    ], "sanzowada", "Color combination 31 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_32, [
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzowada", "Color combination 32 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_33, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 33 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_34, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 34 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_35, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+    ], "sanzowada", "Color combination 35 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_36, [
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzowada", "Color combination 36 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_37, [
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 37 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_38, [
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzowada", "Color combination 38 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_39, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzowada", "Color combination 39 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_40, [
+        RGB(0.7803921568627451, 0.2627450980392157, 0.0),
+    ], "sanzowada", "Color combination 40 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_41, [
+        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzowada", "Color combination 41 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_42, [
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 42 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_43, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzowada", "Color combination 43 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_44, [
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzowada", "Color combination 44 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_45, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+    ], "sanzowada", "Color combination 45 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_46, [
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 46 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_47, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzowada", "Color combination 47 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_48, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzowada", "Color combination 48 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_49, [
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 49 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_50, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzowada", "Color combination 50 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_51, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 51 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_52, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 52 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_53, [
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzowada", "Color combination 53 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_54, [
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzowada", "Color combination 54 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_55, [
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(1.0, 1.0, 1.0),
+    ], "sanzowada", "Color combination 55 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_56, [
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 56 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_57, [
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 57 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_58, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzowada", "Color combination 58 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_59, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+    ], "sanzowada", "Color combination 59 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_60, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzowada", "Color combination 60 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_61, [
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzowada", "Color combination 61 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_62, [
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 62 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_63, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzowada", "Color combination 63 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_64, [
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
+    ], "sanzowada", "Color combination 64 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_65, [
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzowada", "Color combination 65 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_66, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
+    ], "sanzowada", "Color combination 66 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_67, [
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzowada", "Color combination 67 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_68, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(1.0, 1.0, 0.0),
+    ], "sanzowada", "Color combination 68 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_69, [
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 69 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_70, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzowada", "Color combination 70 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_71, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+    ], "sanzowada", "Color combination 71 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_72, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzowada", "Color combination 72 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_73, [
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+    ], "sanzowada", "Color combination 73 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_74, [
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzowada", "Color combination 74 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_75, [
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 75 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_76, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzowada", "Color combination 76 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_77, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+    ], "sanzowada", "Color combination 77 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_78, [
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzowada", "Color combination 78 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_79, [
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzowada", "Color combination 79 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_80, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzowada", "Color combination 80 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_81, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzowada", "Color combination 81 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_82, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzowada", "Color combination 82 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_83, [
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 83 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_84, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzowada", "Color combination 84 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_85, [
+        RGB(0.7803921568627451, 0.2627450980392157, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 85 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_86, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzowada", "Color combination 86 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_87, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+    ], "sanzowada", "Color combination 87 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_88, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 88 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_89, [
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 89 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_90, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzowada", "Color combination 90 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_91, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
+    ], "sanzowada", "Color combination 91 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_92, [
+        RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzowada", "Color combination 92 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_93, [
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzowada", "Color combination 93 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_94, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzowada", "Color combination 94 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_95, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzowada", "Color combination 95 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_96, [
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+    ], "sanzowada", "Color combination 96 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_97, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+    ], "sanzowada", "Color combination 97 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_98, [
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 98 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_99, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzowada", "Color combination 99 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_100, [
+        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
+        RGB(0.43137254901960786, 0.4, 0.8313725490196079),
+    ], "sanzowada", "Color combination 100 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_101, [
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzowada", "Color combination 101 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_102, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
+    ], "sanzowada", "Color combination 102 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_103, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzowada", "Color combination 103 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_104, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    ], "sanzowada", "Color combination 104 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_105, [
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
+    ], "sanzowada", "Color combination 105 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_106, [
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzowada", "Color combination 106 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_107, [
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
+    ], "sanzowada", "Color combination 107 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_108, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+    ], "sanzowada", "Color combination 108 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_109, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
+    ], "sanzowada", "Color combination 109 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_110, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+    ], "sanzowada", "Color combination 110 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_111, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
+    ], "sanzowada", "Color combination 111 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_112, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 112 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_113, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+    ], "sanzowada", "Color combination 113 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_114, [
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 114 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_115, [
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(1.0, 0.2, 0.09803921568627451),
+    ], "sanzowada", "Color combination 115 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_116, [
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzowada", "Color combination 116 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_117, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 117 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_118, [
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+    ], "sanzowada", "Color combination 118 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_119, [
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzowada", "Color combination 119 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_120, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+    ], "sanzowada", "Color combination 120 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_121, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzowada", "Color combination 121 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_122, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzowada", "Color combination 122 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_123, [
+        RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzowada", "Color combination 123 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_124, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.6, 0.7019607843137254, 0.2),
+    ], "sanzowada", "Color combination 124 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_125, [
+        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+        RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 125 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_126, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzowada", "Color combination 126 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_127, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
+    ], "sanzowada", "Color combination 127 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_128, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzowada", "Color combination 128 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_129, [
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 129 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_130, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 130 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_131, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.0, 0.8117647058823529, 0.5686274509803921),
+    ], "sanzowada", "Color combination 131 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_132, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+    ], "sanzowada", "Color combination 132 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_133, [
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzowada", "Color combination 133 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_134, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 134 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_135, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 135 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_136, [
+        RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
+        RGB(0.09803921568627451, 0.8, 0.2),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 136 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_137, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    ], "sanzowada", "Color combination 137 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_138, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzowada", "Color combination 138 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_139, [
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 139 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_140, [
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 140 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_141, [
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzowada", "Color combination 141 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_142, [
+        RGB(0.6196078431372549, 0.09803921568627451, 0.30196078431372547),
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 142 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_143, [
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzowada", "Color combination 143 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_144, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 144 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_145, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzowada", "Color combination 145 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_146, [
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzowada", "Color combination 146 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_147, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzowada", "Color combination 147 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_148, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzowada", "Color combination 148 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_149, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzowada", "Color combination 149 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_150, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzowada", "Color combination 150 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_151, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(1.0, 0.5490196078431373, 0.0),
+    ], "sanzowada", "Color combination 151 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_152, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzowada", "Color combination 152 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_153, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.6705882352941176, 0.0),
+    ], "sanzowada", "Color combination 153 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_154, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 154 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_155, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzowada", "Color combination 155 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_156, [
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 156 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_157, [
+        RGB(0.43529411764705883, 0.0, 0.2627450980392157),
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzowada", "Color combination 157 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_158, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzowada", "Color combination 158 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_159, [
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.5019607843137255, 1.0, 0.8),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzowada", "Color combination 159 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_160, [
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+    ], "sanzowada", "Color combination 160 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_161, [
+        RGB(0.4235294117647059, 0.16862745098039217, 0.06666666666666667),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzowada", "Color combination 161 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_162, [
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+    ], "sanzowada", "Color combination 162 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_163, [
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 163 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_164, [
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 164 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_165, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+    ], "sanzowada", "Color combination 165 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_166, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzowada", "Color combination 166 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_167, [
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzowada", "Color combination 167 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_168, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+    ], "sanzowada", "Color combination 168 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_169, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzowada", "Color combination 169 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_170, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 170 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_171, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzowada", "Color combination 171 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_172, [
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 172 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_173, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzowada", "Color combination 173 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_174, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzowada", "Color combination 174 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_175, [
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzowada", "Color combination 175 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_176, [
+        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzowada", "Color combination 176 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_177, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+    ], "sanzowada", "Color combination 177 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_178, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzowada", "Color combination 178 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_179, [
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(0.9803921568627451, 0.5803921568627451, 0.25882352941176473),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzowada", "Color combination 179 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_180, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 180 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_181, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzowada", "Color combination 181 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_182, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzowada", "Color combination 182 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_183, [
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
+        RGB(0.49411764705882355, 0.18823529411764706, 0.4588235294117647),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 183 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_184, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.4627450980392157, 0.5176470588235295, 0.3058823529411765),
+    ], "sanzowada", "Color combination 184 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_185, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+    ], "sanzowada", "Color combination 185 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_186, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 186 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_187, [
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzowada", "Color combination 187 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_188, [
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzowada", "Color combination 188 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_189, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzowada", "Color combination 189 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_190, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 190 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_191, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 191 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_192, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.21176470588235294, 0.13725490196078433, 0.01568627450980392),
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
+    ], "sanzowada", "Color combination 192 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_193, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
+    ], "sanzowada", "Color combination 193 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_194, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzowada", "Color combination 194 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_195, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 195 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_196, [
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzowada", "Color combination 196 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_197, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.30196078431372547, 0.3215686274509804, 0.8705882352941177),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 197 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_198, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 198 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_199, [
+        RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
+        RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzowada", "Color combination 199 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_200, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
+    ], "sanzowada", "Color combination 200 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_201, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzowada", "Color combination 201 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_202, [
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 202 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_203, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzowada", "Color combination 203 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_204, [
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzowada", "Color combination 204 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_205, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 205 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_206, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.7607843137254902, 0.3803921568627451, 0.17254901960784313),
+    ], "sanzowada", "Color combination 206 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_207, [
+        RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 207 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_208, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 208 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_209, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 209 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_210, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+    ], "sanzowada", "Color combination 210 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_211, [
+        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+        RGB(0.6, 0.7019607843137254, 0.2),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzowada", "Color combination 211 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_212, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 212 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_213, [
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzowada", "Color combination 213 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_214, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 214 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_215, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 215 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_216, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 216 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_217, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzowada", "Color combination 217 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_218, [
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+        RGB(0.3607843137254902, 0.4470588235294118, 0.5294117647058824),
+    ], "sanzowada", "Color combination 218 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_219, [
+        RGB(0.9803921568627451, 0.16862745098039217, 0.0),
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzowada", "Color combination 219 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_220, [
+        RGB(0.7254901960784313, 0.0, 0.47058823529411764),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzowada", "Color combination 220 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_221, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 221 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_222, [
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.7529411764705882, 0.3215686274509804, 0.0),
+    ], "sanzowada", "Color combination 222 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_223, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzowada", "Color combination 223 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_224, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzowada", "Color combination 224 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_225, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
+    ], "sanzowada", "Color combination 225 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_226, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 226 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_227, [
+        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzowada", "Color combination 227 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_228, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 228 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_229, [
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 229 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_230, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzowada", "Color combination 230 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_231, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+    ], "sanzowada", "Color combination 231 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_232, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.0, 0.03137254901960784, 0.19215686274509805),
+    ], "sanzowada", "Color combination 232 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_233, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.5333333333333333, 0.5529411764705883, 0.16470588235294117),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 233 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_234, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+    ], "sanzowada", "Color combination 234 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_235, [
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzowada", "Color combination 235 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_236, [
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.0, 0.1411764705882353, 0.8),
+        RGB(0.4588235294117647, 0.25882352941176473, 0.3764705882352941),
+    ], "sanzowada", "Color combination 236 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_237, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.33725490196078434, 0.6666666666666666, 0.4117647058823529),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 237 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_238, [
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzowada", "Color combination 238 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_239, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.7686274509803922, 0.7490196078431373, 0.2),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+    ], "sanzowada", "Color combination 239 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_240, [
+        RGB(1.0, 0.47058823529411764, 0.5490196078431373),
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzowada", "Color combination 240 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_241, [
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+    ], "sanzowada", "Color combination 241 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_242, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 242 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_243, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 243 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_244, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.7803921568627451, 0.2627450980392157, 0.0),
+        RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 244 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_245, [
+        RGB(0.6313725490196078, 0.043137254901960784, 0.16862745098039217),
+        RGB(0.43137254901960786, 0.6627450980392157, 0.0),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 245 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_246, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+    ], "sanzowada", "Color combination 246 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_247, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.0, 0.1411764705882353, 0.8),
+    ], "sanzowada", "Color combination 247 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_248, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7137254901960784, 0.5176470588235295, 0.0),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+        RGB(0.3254901960784314, 0.13333333333333333, 0.3607843137254902),
+    ], "sanzowada", "Color combination 248 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_249, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.2549019607843137, 0.4666666666666667, 0.4666666666666667),
+    ], "sanzowada", "Color combination 249 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_250, [
+        RGB(0.7686274509803922, 0.7490196078431373, 0.2),
+        RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(0.2, 1.0, 0.49019607843137253),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzowada", "Color combination 250 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_251, [
+        RGB(0.6313725490196078, 0.0, 0.27058823529411763),
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 251 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_252, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7294117647058823, 0.6509803921568628, 0.0),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzowada", "Color combination 252 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_253, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 253 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_254, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
+    ], "sanzowada", "Color combination 254 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_255, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7686274509803922, 0.7490196078431373, 0.2),
+        RGB(0.5019607843137255, 1.0, 0.8),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 255 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_256, [
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.09803921568627451, 0.8, 0.2),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 256 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_257, [
+        RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzowada", "Color combination 257 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_258, [
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 258 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_259, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzowada", "Color combination 259 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_260, [
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.7019607843137254, 0.9098039215686274, 0.7607843137254902),
+        RGB(0.2, 1.0, 0.49019607843137253),
+    ], "sanzowada", "Color combination 260 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_261, [
+        RGB(0.6313725490196078, 0.0, 0.27058823529411763),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.5019607843137255, 1.0, 0.8),
+        RGB(0.611764705882353, 0.6980392156862745, 0.6196078431372549),
+    ], "sanzowada", "Color combination 261 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_262, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.6509803921568628, 0.8313725490196079, 0.050980392156862744),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzowada", "Color combination 262 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_263, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 263 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_264, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(0.9098039215686274, 0.09803921568627451, 0.0),
+        RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
+        RGB(0.1607843137254902, 0.7411764705882353, 0.6784313725490196),
+    ], "sanzowada", "Color combination 264 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_265, [
+        RGB(0.8509803921568627, 0.30196078431372547, 0.6),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.6, 0.7019607843137254, 0.2),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzowada", "Color combination 265 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_266, [
+        RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzowada", "Color combination 266 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_267, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 267 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_268, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzowada", "Color combination 268 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_269, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 269 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_270, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzowada", "Color combination 270 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_271, [
+        RGB(0.7254901960784313, 0.0, 0.47058823529411764),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzowada", "Color combination 271 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_272, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(1.0, 0.3215686274509804, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 272 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_273, [
+        RGB(1.0, 0.7019607843137254, 0.9411764705882353),
+        RGB(0.43529411764705883, 0.0, 0.2627450980392157),
+        RGB(0.6078431372549019, 0.3254901960784314, 0.2823529411764706),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 273 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_274, [
+        RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+    ], "sanzowada", "Color combination 274 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_275, [
+        RGB(0.788235294117647, 0.18823529411764706, 0.24313725490196078),
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzowada", "Color combination 275 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_276, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 276 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_277, [
+        RGB(1.0, 0.30196078431372547, 0.788235294117647),
+        RGB(0.7019607843137254, 0.09803921568627451, 0.6705882352941176),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzowada", "Color combination 277 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_278, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.8196078431372549, 0.7411764705882353, 0.09803921568627451),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzowada", "Color combination 278 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_279, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.050980392156862744, 0.16862745098039217, 0.3215686274509804),
+    ], "sanzowada", "Color combination 279 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_280, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+    ], "sanzowada", "Color combination 280 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_281, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 281 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_282, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.7607843137254902, 0.592156862745098, 0.35294117647058826),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+    ], "sanzowada", "Color combination 282 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_283, [
+        RGB(0.6549019607843137, 0.21568627450980393, 0.29411764705882354),
+        RGB(0.45098039215686275, 0.058823529411764705, 0.12156862745098039),
+        RGB(0.5215686274509804, 0.7215686274509804, 0.3411764705882353),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+    ], "sanzowada", "Color combination 283 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_284, [
+        RGB(0.9294117647058824, 0.23921568627450981, 0.4),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.2, 1.0, 0.49019607843137253),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzowada", "Color combination 284 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_285, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzowada", "Color combination 285 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_286, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.0, 0.8117647058823529, 0.5686274509803921),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 286 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_287, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7686274509803922, 0.7490196078431373, 0.2),
+        RGB(0.6705882352941176, 0.9607843137254902, 0.9294117647058824),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzowada", "Color combination 287 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_288, [
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.3137254901960784, 0.23921568627450981, 0.0),
+        RGB(0.4196078431372549, 0.1803921568627451, 0.38823529411764707),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 288 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_289, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzowada", "Color combination 289 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_290, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.25098039215686274, 0.32941176470588235, 0.08627450980392157),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzowada", "Color combination 290 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_291, [
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+        RGB(0.2, 1.0, 0.49019607843137253),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzowada", "Color combination 291 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_292, [
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.7647058823529411, 0.6470588235294118, 0.3607843137254902),
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+    ], "sanzowada", "Color combination 292 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_293, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
+        RGB(0.25098039215686274, 0.788235294117647, 0.27058823529411763),
+    ], "sanzowada", "Color combination 293 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_294, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 294 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_295, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+    ], "sanzowada", "Color combination 295 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_296, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.3686274509803922, 0.25098039215686274, 0.09019607843137255),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 296 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_297, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.34509803921568627, 0.4666666666666667, 0.11764705882352941),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 297 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_298, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(1.0, 0.2, 0.09803921568627451),
+    ], "sanzowada", "Color combination 298 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_299, [
+        RGB(0.8, 0.10196078431372549, 0.592156862745098),
+        RGB(0.9607843137254902, 0.6, 0.5803921568627451),
+        RGB(0.43137254901960786, 0.6627450980392157, 0.0),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 299 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_300, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.5019607843137255, 1.0, 0.8),
+    ], "sanzowada", "Color combination 300 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_301, [
+        RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+    ], "sanzowada", "Color combination 301 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_302, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 302 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_303, [
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 303 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_304, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.49411764705882355, 0.5294117647058824, 0.2627450980392157),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+    ], "sanzowada", "Color combination 304 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_305, [
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzowada", "Color combination 305 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_306, [
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.0, 0.8509803921568627, 0.45098039215686275),
+        RGB(0.09803921568627451, 0.8, 0.2),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+    ], "sanzowada", "Color combination 306 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_307, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(0.7215686274509804, 0.7215686274509804, 1.0),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzowada", "Color combination 307 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_308, [
+        RGB(0.9019607843137255, 0.6784313725490196, 0.8117647058823529),
+        RGB(0.8196078431372549, 0.6901960784313725, 0.7019607843137254),
+        RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
+        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+    ], "sanzowada", "Color combination 308 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_309, [
+        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 309 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_310, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.9490196078431372, 0.6784313725490196, 0.47058823529411764),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+    ], "sanzowada", "Color combination 310 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_311, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.7019607843137254, 0.8509803921568627, 0.6392156862745098),
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+    ], "sanzowada", "Color combination 311 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_312, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.396078431372549, 0.6627450980392157, 0.5607843137254902),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+    ], "sanzowada", "Color combination 312 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_313, [
+        RGB(0.8392156862745098, 0.0, 0.21176470588235294),
+        RGB(1.0, 1.0, 0.0),
+        RGB(0.10588235294117647, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 313 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_314, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.0, 0.1411764705882353, 0.8),
+        RGB(0.17647058823529413, 0.0, 0.3764705882352941),
+    ], "sanzowada", "Color combination 314 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_315, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+    ], "sanzowada", "Color combination 315 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_316, [
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(0.09803921568627451, 0.8, 0.2),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+        RGB(0.20392156862745098, 0.0, 0.6392156862745098),
+    ], "sanzowada", "Color combination 316 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_317, [
+        RGB(1.0, 0.7490196078431373, 0.6),
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+    ], "sanzowada", "Color combination 317 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_318, [
+        RGB(0.4392156862745098, 0.4117647058823529, 0.20392156862745098),
+        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzowada", "Color combination 318 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_319, [
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(1.0, 0.9019607843137255, 0.0),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+    ], "sanzowada", "Color combination 319 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_320, [
+        RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.43137254901960786, 0.6627450980392157, 0.0),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzowada", "Color combination 320 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_321, [
+        RGB(0.6901960784313725, 0.5254901960784314, 0.6),
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+    ], "sanzowada", "Color combination 321 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_322, [
+        RGB(0.9490196078431372, 0.0, 0.0),
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzowada", "Color combination 322 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_323, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.396078431372549, 0.07450980392156863, 0.0),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 323 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_324, [
+        RGB(0.6627450980392157, 0.023529411764705882, 0.21176470588235294),
+        RGB(0.30980392156862746, 0.5607843137254902, 0.9019607843137255),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+    ], "sanzowada", "Color combination 324 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_325, [
+        RGB(0.9019607843137255, 0.1803921568627451, 0.45098039215686275),
+        RGB(0.9803921568627451, 0.9294117647058824, 0.5607843137254902),
+        RGB(0.8784313725490196, 0.7215686274509804, 0.12156862745098039),
+        RGB(0.058823529411764705, 0.14901960784313725, 0.12156862745098039),
+    ], "sanzowada", "Color combination 325 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_326, [
+        RGB(0.9607843137254902, 0.9607843137254902, 0.7215686274509804),
+        RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
+        RGB(0.47843137254901963, 1.0, 0.0),
+    ], "sanzowada", "Color combination 326 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_327, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.7215686274509804, 0.3686274509803922, 0.0),
+        RGB(0.7529411764705882, 0.7058823529411765, 0.5647058823529412),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzowada", "Color combination 327 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_328, [
+        RGB(0.6392156862745098, 0.12941176470588237, 0.0),
+        RGB(1.0, 0.45098039215686275, 0.25098039215686274),
+        RGB(0.13725490196078433, 0.7568627450980392, 0.48627450980392156),
+    ], "sanzowada", "Color combination 328 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_329, [
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 329 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_330, [
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+        RGB(0.5882352941176471, 0.7490196078431373, 0.9019607843137255),
+        RGB(0.17647058823529413, 0.7372549019607844, 0.5803921568627451),
+    ], "sanzowada", "Color combination 330 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_331, [
+        RGB(0.8, 0.10196078431372549, 0.592156862745098),
+        RGB(0.023529411764705882, 0.0, 0.30980392156862746),
+        RGB(0.7490196078431373, 0.21176470588235294, 0.8784313725490196),
+        RGB(0.5686274509803921, 0.3803921568627451, 0.9490196078431372),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+    ], "sanzowada", "Color combination 331 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_332, [
+        RGB(1.0, 0.45098039215686275, 0.6),
+        RGB(0.8352941176470589, 0.047058823529411764, 0.25882352941176473),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+    ], "sanzowada", "Color combination 332 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_333, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.9490196078431372, 1.0, 0.14901960784313725),
+        RGB(0.5803921568627451, 1.0, 0.5803921568627451),
+        RGB(0.050980392156862744, 0.4588235294117647, 1.0),
+    ], "sanzowada", "Color combination 333 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_334, [
+        RGB(1.0, 0.8117647058823529, 0.7686274509803922),
+        RGB(0.44313725490196076, 0.5254901960784314, 0.0),
+        RGB(0.6509803921568628, 1.0, 0.2784313725490196),
+        RGB(0.0, 0.5411764705882353, 0.6313725490196078),
+    ], "sanzowada", "Color combination 334 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_335, [
+        RGB(0.4549019607843137, 0.03529411764705882, 0.03529411764705882),
+        RGB(1.0, 0.5490196078431373, 0.0),
+        RGB(0.14901960784313725, 0.09803921568627451, 0.8196078431372549),
+        RGB(0.10588235294117647, 0.21176470588235294, 0.26666666666666666),
+    ], "sanzowada", "Color combination 335 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_336, [
+        RGB(1.0, 0.3686274509803922, 0.7686274509803922),
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(1.0, 0.9607843137254902, 0.6196078431372549),
+        RGB(0.19607843137254902, 0.3058823529411765, 0.16470588235294117),
+    ], "sanzowada", "Color combination 336 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_337, [
+        RGB(0.3607843137254902, 0.17254901960784313, 0.27058823529411763),
+        RGB(0.8, 0.5215686274509804, 0.8196078431372549),
+        RGB(0.3254901960784314, 0.09019607843137255, 0.27058823529411763),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 337 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_338, [
+        RGB(1.0, 0.6705882352941176, 0.0),
+        RGB(0.0, 0.34901960784313724, 0.1803921568627451),
+        RGB(0.7490196078431373, 0.6705882352941176, 0.8),
+    ], "sanzowada", "Color combination 338 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_339, [
+        RGB(0.8509803921568627, 0.6196078431372549, 0.45098039215686275),
+        RGB(0.8705882352941177, 0.27058823529411763, 0.0),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+        RGB(0.12549019607843137, 0.17647058823529413, 0.5215686274509804),
+    ], "sanzowada", "Color combination 339 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_340, [
+        RGB(1.0, 0.2, 0.09803921568627451),
+        RGB(0.2, 1.0, 0.49019607843137253),
+        RGB(0.7098039215686275, 0.8196078431372549, 0.8),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 340 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_341, [
+        RGB(1.0, 0.3803921568627451, 0.4196078431372549),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.6509803921568628, 0.9019607843137255, 0.8588235294117647),
+    ], "sanzowada", "Color combination 341 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_342, [
+        RGB(1.0, 0.6509803921568628, 0.8509803921568627),
+        RGB(1.0, 0.7215686274509804, 0.3215686274509804),
+        RGB(0.5490196078431373, 0.396078431372549, 0.06274509803921569),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+    ], "sanzowada", "Color combination 342 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_343, [
+        RGB(0.6627450980392157, 0.20392156862745098, 0.0),
+        RGB(0.9215686274509803, 0.8509803921568627, 0.6),
+        RGB(0.3137254901960784, 0.32941176470588235, 0.13725490196078433),
+    ], "sanzowada", "Color combination 343 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_344, [
+        RGB(1.0, 0.7490196078431373, 0.43137254901960786),
+        RGB(0.0, 0.1411764705882353, 0.8),
+        RGB(0.611764705882353, 0.3215686274509804, 0.9490196078431372),
+        RGB(0.0, 0.0, 0.0),
+    ], "sanzowada", "Color combination 344 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_345, [
+        RGB(0.40784313725490196, 0.09803921568627451, 0.08627450980392157),
+        RGB(0.7490196078431373, 1.0, 0.9019607843137255),
+        RGB(0.4196078431372549, 1.0, 0.7019607843137254),
+        RGB(0.2784313725490196, 0.2, 1.0),
+    ], "sanzowada", "Color combination 345 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_346, [
+        RGB(0.7098039215686275, 1.0, 0.7607843137254902),
+        RGB(0.7411764705882353, 0.9490196078431372, 0.14901960784313725),
+        RGB(0.3607843137254902, 0.5411764705882353, 0.45098039215686275),
+    ], "sanzowada", "Color combination 346 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_347, [
+        RGB(0.6, 0.7019607843137254, 0.2),
+        RGB(0.2, 1.0, 0.49019607843137253),
+        RGB(0.0, 0.3411764705882353, 0.7294117647058823),
+        RGB(0.7215686274509804, 0.4588235294117647, 0.9215686274509803),
+    ], "sanzowada", "Color combination 347 from Sanzo Wada's Dictionary of Color Combinations")
+loadcolorscheme(:sanzowada_348, [
+        RGB(0.7372549019607844, 0.8274509803921568, 0.5098039215686274),
+        RGB(0.19607843137254902, 0.5568627450980392, 0.07450980392156863),
+        RGB(0.09019607843137255, 0.15294117647058825, 0.07450980392156863),
+        RGB(0.20392156862745098, 0.0, 0.34901960784313724),
+    ], "sanzowada", "Color combination 348 from Sanzo Wada's Dictionary of Color Combinations")

--- a/docs/src/catalogue.md
+++ b/docs/src/catalogue.md
@@ -275,6 +275,14 @@ using Luxor, ColorSchemes # hide
 ColorSchemeCategory("Feathers") # hide
 ```
 
+# sanzo
+Color combinations derived from "A Dictionary of Color Combinations", a book based on the original 6-volumes of color studies called _Haishoku Soukan_ by [Sanzo Wada](https://en.wikipedia.org/wiki/Sanzo_Wada), a Japanese artist and designer.
+
+```@example catalog
+using Luxor, ColorSchemes # hide
+ColorSchemeCategory("sanzo") # hide
+```
+
 # general and miscellaneous
 
 ```@example catalog

--- a/src/ColorSchemes.jl
+++ b/src/ColorSchemes.jl
@@ -144,6 +144,7 @@ function loadallschemes()
     include(joinpath(datadir, "feathers.jl"))
     include(joinpath(datadir, "progress.jl"))
     include(joinpath(datadir, "catppuccin_scheme.jl"))
+    include(joinpath(datadir, "sanzowada.jl"))
 
     # create them as constants...
     for key in keys(colorschemes)

--- a/src/ColorSchemes.jl
+++ b/src/ColorSchemes.jl
@@ -144,7 +144,7 @@ function loadallschemes()
     include(joinpath(datadir, "feathers.jl"))
     include(joinpath(datadir, "progress.jl"))
     include(joinpath(datadir, "catppuccin_scheme.jl"))
-    include(joinpath(datadir, "sanzowada.jl"))
+    include(joinpath(datadir, "sanzo.jl"))
 
     # create them as constants...
     for key in keys(colorschemes)


### PR DESCRIPTION
Add color combinations from "A dictionary of color combinations" by Sanzo Wada. Names are given as:

`sanzo_xxx` where `xxx` is the number of the color combination (e.g. 001). 